### PR TITLE
Update repository URL in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Muter is available through [Homebrew](https://brew.sh/). Run the following comma
 You can build Muter from source, and get the latest set of features/improvements, by running the following: 
 
 ```
-git clone https://github.com/SeanROlszewski/muter.git
+git clone https://github.com/muter-mutation-testing/muter.git
 cd muter
 make install
 ```


### PR DESCRIPTION
Same as https://github.com/muter-mutation-testing/muter/commit/19d4c749ff137a77ab16e030488e15d437274f60.

The older URL (https://github.com/SeanROlszewski/muter.git) redirects to the newer (https://github.com/muter-mutation-testing/muter.git) so it is harmless but updating the URL would be less confusing.