### PR TITLE
Support marking mutations to skip

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,9 @@ Muter defaults to run when you don't specify any subcommands
 ### Within Xcode
 Build (Cmd + B) your aggregate build target and let Muter run. The mutants which survive testing will be called out in the issue navigator. Once the target finishes building, testing has completed.
 
+### Skipping Mutations
+You can mark specific lines to skip mutations on, rather than entire files, by adding to them a line comment containing the text `muter:skip` (inspired by a similar feature in Swiftlint). This is mostly useful after the first run, if you conclude that specific uncaught mutants shouldn't be covered by your test suite – e.g. logging-related code, specific lines accessing real network/timers etc. This will prevent Muter from wasting time on testing them on subsequent runs, and reduce the 'noise'.
+
 ## Assumptions
 - Muter assumes you always put spaces around your operators. For example, it expects an equality check to look like
 

--- a/Sources/muterCore/CLICommands/RunCommand/Steps/DiscoverMutationPoints+Exclude.swift
+++ b/Sources/muterCore/CLICommands/RunCommand/Steps/DiscoverMutationPoints+Exclude.swift
@@ -8,58 +8,25 @@
 // This file is intended to include all of the code related to excluding specific mutation points, for use by struct DiscoverMutationPoints.
 
 import Foundation
-import struct SwiftSyntax.AbsolutePosition
+import SwiftSyntax
 
 let muterSkipMarker = "muter:skip"
 
-struct ExclusionPoint {
-    let mutationOperatorId: MutationOperator.Id?
-    let filePath: String
-    let line: Int
-}
+// Currently supports only line comments (in block comments, would need to detect in which actual line the skip marker appears - and if it isn't the first or last line, it won't contain code anyway)
+class ExcludedMutationPointsDetector: SyntaxVisitor {
 
-extension DiscoverMutationPoints {
-    func loadMutationPointsToExclude(inFilesAt filePaths: [String]) -> [ExclusionPoint] {
-        let launchPath = "/usr/bin/fgrep"
-        let args: [String] = ["-Hn", muterSkipMarker] + filePaths   // -H shows the filename, -n shows the line number
-        guard let output = shell(launchPath: launchPath, arguments: args) else {
-            return []
-        }
-        return output.split(separator: "\n").compactMap {
-            // fgrep -Hn result format is <filename>:<line number>: <source line>
-            let components = $0.split(separator: ":", maxSplits: 3)
-            guard components.count >= 2, let path = components.first, let line = Int(components[1]) else {
-                return nil
+    private(set) var excludedLines: [Int] = []
+    
+    override func visitPre(_ node: Syntax) {
+        let markedForExclusion = node.leadingTrivia?.contains {
+            if case .lineComment(let commentText) = $0 {
+                return commentText.contains(muterSkipMarker)
+            } else {
+                return false
             }
-            return ExclusionPoint(mutationOperatorId: nil,  // TODO: Get the real mutation operator, if specified
-                filePath: String(path),
-                line: line)
         }
-    }
-}
-
-// Source: https://stackoverflow.com/questions/48376150/how-do-i-run-shell-command-in-swift
-func shell(launchPath path: String, arguments args: [String]) -> String? {
-    let task = Process()
-    task.launchPath = path
-    task.arguments = args
-
-    let pipe = Pipe()
-    task.standardOutput = pipe
-//    task.standardError = pipe // Output errors to console
-    task.launch()
-
-    let data = pipe.fileHandleForReading.readDataToEndOfFile()
-    let output = String(data: data, encoding: .utf8)
-    task.waitUntilExit()
-
-    return output
-}
-
-extension MutationPoint {
-    func matchesByLine(_ exclusionPoint: ExclusionPoint) -> Bool {
-        return self.filePath == exclusionPoint.filePath
-            && (self.mutationOperatorId == exclusionPoint.mutationOperatorId || exclusionPoint.mutationOperatorId == nil)
-            && self.position.line == exclusionPoint.line
+        if markedForExclusion == true {
+            excludedLines.append(node.position.line)
+        }
     }
 }

--- a/Sources/muterCore/CLICommands/RunCommand/Steps/DiscoverMutationPoints+Exclude.swift
+++ b/Sources/muterCore/CLICommands/RunCommand/Steps/DiscoverMutationPoints+Exclude.swift
@@ -10,13 +10,13 @@
 import Foundation
 import SwiftSyntax
 
-let muterSkipMarker = "muter:skip"
-
 // Currently supports only line comments (in block comments, would need to detect in which actual line the skip marker appears - and if it isn't the first or last line, it won't contain code anyway)
-class ExcludedMutationPointsDetector: SyntaxVisitor {
+final class ExcludedMutationPointsDetector: SyntaxVisitor {
 
     private(set) var excludedLines: [Int] = []
     
+    private let muterSkipMarker = "muter:skip"
+
     override func visitPre(_ node: Syntax) {
         let markedForExclusion = node.leadingTrivia?.contains {
             if case .lineComment(let commentText) = $0 {

--- a/Sources/muterCore/CLICommands/RunCommand/Steps/DiscoverMutationPoints+Exclude.swift
+++ b/Sources/muterCore/CLICommands/RunCommand/Steps/DiscoverMutationPoints+Exclude.swift
@@ -1,5 +1,5 @@
 //
-//  DiscoverMutationPoints+exclude.swift
+//  DiscoverMutationPoints+Exclude.swift
 //  muterCore
 //
 //  Created by Uriah Eisenstein on 06/01/2020.

--- a/Sources/muterCore/CLICommands/RunCommand/Steps/DiscoverMutationPoints+exclude.swift
+++ b/Sources/muterCore/CLICommands/RunCommand/Steps/DiscoverMutationPoints+exclude.swift
@@ -1,0 +1,59 @@
+//
+//  DiscoverMutationPoints+exclude.swift
+//  muterCore
+//
+//  Created by Uriah Eisenstein on 06/01/2020.
+//
+
+// This file is intended to include all of the code related to excluding specific mutation points, for use by struct DiscoverMutationPoints.
+
+import Foundation
+import struct SwiftSyntax.AbsolutePosition
+
+let muterSkipMarker = "muter:skip"
+
+extension DiscoverMutationPoints {
+    func loadMutationPointsToExclude(inFilesAt filePaths: [String]) -> [MutationPoint] {
+        let launchPath = "/usr/bin/fgrep"
+        let args: [String] = ["-Hn", muterSkipMarker] + filePaths   // -H shows the filename, -n shows the line number
+        guard let output = shell(launchPath: launchPath, arguments: args) else {
+            return []
+        }
+        return output.split(separator: "\n").compactMap {
+            // fgrep -Hn result format is <filename>:<line number>: <source line>
+            let components = $0.split(separator: ":", maxSplits: 3)
+            guard components.count >= 2, let path = components.first, let line = Int(components[1]) else {
+                return nil
+            }
+            return MutationPoint(mutationOperatorId: .ror,  // TODO: Get the real mutation operator, or let it be optional
+                                 filePath: String(path),
+                                 position: AbsolutePosition(line: line, column: -1, utf8Offset: -1))
+        }
+    }
+}
+
+// Source: https://stackoverflow.com/questions/48376150/how-do-i-run-shell-command-in-swift
+func shell(launchPath path: String, arguments args: [String]) -> String? {
+    let task = Process()
+    task.launchPath = path
+    task.arguments = args
+
+    let pipe = Pipe()
+    task.standardOutput = pipe
+//    task.standardError = pipe // Output errors to console
+    task.launch()
+
+    let data = pipe.fileHandleForReading.readDataToEndOfFile()
+    let output = String(data: data, encoding: .utf8)
+    task.waitUntilExit()
+
+    return output
+}
+
+extension MutationPoint {
+    func matchesByLine(_ other: MutationPoint) -> Bool {
+        return self.filePath == other.filePath
+//            && self.mutationOperatorId == other.mutationOperatorId    // Ignoring mutation operator for now
+            && self.position.line == other.position.line
+    }
+}

--- a/Sources/muterCore/CLICommands/RunCommand/Steps/DiscoverMutationPoints.swift
+++ b/Sources/muterCore/CLICommands/RunCommand/Steps/DiscoverMutationPoints.swift
@@ -7,7 +7,7 @@ struct DiscoverMutationPoints: RunCommandStep {
     func run(with state: AnyRunCommandState) -> Result<[RunCommandState.Change], MuterError> {
         
         notificationCenter.post(name: .mutationPointDiscoveryStarted, object: nil)
-        
+
         let (mutationPoints, sourceCodeByFilePath) = discoverMutationPoints(inFilesAt: state.sourceFileCandidates)
         
         notificationCenter.post(name: .mutationPointDiscoveryFinished, object: mutationPoints)
@@ -26,14 +26,18 @@ private extension DiscoverMutationPoints {
     func discoverMutationPoints(inFilesAt filePaths: [String]) -> (mutationPoints: [MutationPoint], sourceCodeByFilePath: [FilePath: SourceFileSyntax]) {
         
         var sourceCodeByFilePath: [FilePath: SourceFileSyntax] = [:]
+        let excludedMutationPoints = loadMutationPointsToExclude(inFilesAt: filePaths)
+
         let mutationPoints: [MutationPoint] = filePaths.accumulate(into: []) { alreadyDiscoveredMutationPoints, path in
             
             guard pathContainsDotSwift(path),
                 let source = sourceCode(fromFileAt: path) else {
                     return alreadyDiscoveredMutationPoints
             }
-            
-            let newMutationPoints = discoverNewMutationPoints(inFileAt: path, containing: source).sorted(by: filePositionOrder)
+
+            let newMutationPoints = discoverNewMutationPoints(inFileAt: path, containing: source)
+                .filter { !excludedMutationPoints.contains(where: $0.matchesByLine) }
+                .sorted(by: filePositionOrder)
             
             if !newMutationPoints.isEmpty {
                 sourceCodeByFilePath[path] = source

--- a/Tests/fixtures/sample with mutations marked for skipping.swift
+++ b/Tests/fixtures/sample with mutations marked for skipping.swift
@@ -1,0 +1,5 @@
+
+func f() {
+    doSomething(testableSideEffect: true)
+    doSomething(testableSideEffect: false)  // muter:skip
+}


### PR DESCRIPTION
Skip mutations in source lines containing the text "muter:skip" in a line comment (inspired by "swiftlint:skip"). This allows marking false positives after a Muter run, to prevent them from wasting time and cluttering the results on subsequent runs.

(Not sure whom to tag… intended to tag Sean Olszewski but can't find him in the list)

* Documentation not updated, will update of course if this PR gets considered for merging.