### PR TITLE
Fix Curry usage for swift 5.1

### DIFF
--- a/Sources/muterCore/CLICommands/RunCommand/RunCommand.swift
+++ b/Sources/muterCore/CLICommands/RunCommand/RunCommand.swift
@@ -65,8 +65,12 @@ public struct RunCommandOptions: OptionsProtocol {
         filesToMutate = list
     }
 
+    private static func create(_ shouldOutputJSON: Bool) -> (Bool) -> ([String]) -> RunCommandOptions {
+        return { shouldOutputXcode in { filesToMutate in RunCommandOptions(shouldOutputJSON: shouldOutputJSON, shouldOutputXcode: shouldOutputXcode, filesToMutate: filesToMutate) } }
+    }
+
     public static func evaluate(_ mode: CommandMode) -> Result<RunCommandOptions, CommandantError<ClientError>>  {
-        return curry(self.init)
+        return create
             <*> mode <| Option(key: "output-json", defaultValue: false, usage: "Whether or not Muter should output a json report after it's finished running.")
             <*> mode <| Option(key: "output-xcode", defaultValue: false, usage: "Whether or not Muter should output to Xcode after it's finished running.")
             <*> mode <| Option(


### PR DESCRIPTION
With swift 5.1 `mutter` compilation fails with error
```
~/muter/Sources/muterCore/CLICommands/RunCommand/RunCommand.swift:65:27: error: partial application of 'mutating' method is not allowed
        return curry(self.init)
```

Replacing `curry` function with the chain of closures helps
This is the copy of the #131