### PR TITLE
Add version check on FileHandle

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -26,8 +26,14 @@ private struct Executable {
 
 extension Pipe {
     func readStringToEndOfFile() -> String? {
-        try? fileHandleForReading.readToEnd()
-            .flatMap { String(data: $0, encoding: .utf8) }
+        let data: Data
+        if #available(OSX 10.15.4, *) {
+            data = (try? fileHandleForReading.readToEnd()) ?? Data()
+        } else {
+            data = fileHandleForReading.readDataToEndOfFile()
+        }
+        
+        return String(data: data, encoding: .utf8)
     }
 }
 


### PR DESCRIPTION
on Big Sur `FileHandle` has a check for os versions.

```swift
extension FileHandle {
    @available(macOS 10.15.4, iOS 13.4, watchOS 6.2, tvOS 13.4, *)
    public func readToEnd() throws -> Data?
```