### PR TITLE
Never mutate a manifest file

### DIFF
--- a/Sources/muterCore/Configuration/configurationGeneration.swift
+++ b/Sources/muterCore/Configuration/configurationGeneration.swift
@@ -75,7 +75,7 @@ private extension MuterConfiguration {
     
     static func generateSPMConfiguration(from directoryContents: [URL]) -> MuterConfiguration? {
         if directoryContents.contains(where: { $0.lastPathComponent == "Package.swift" }) {
-            return MuterConfiguration(executable: "/usr/bin/swift", arguments: ["test"], excludeList: [])
+            return MuterConfiguration(executable: "/usr/bin/swift", arguments: ["test"], excludeList: ["Package.swift"])
         }
         
         return nil

--- a/Tests/Configuration/configurationGenerationSpec.swift
+++ b/Tests/Configuration/configurationGenerationSpec.swift
@@ -23,7 +23,8 @@ class ConfigurationGenerationSpec: QuickSpec {
                         
                         let generatedConfiguration = MuterConfiguration(from: projectDirectoryContents)
                         expect(generatedConfiguration) == MuterConfiguration(executable: "/usr/bin/swift",
-                                                                             arguments: ["test"])
+                                                                             arguments: ["test"],
+                                                                             excludeList: ["Package.swift"])
                     }
                 }
                 context("when there is an Xcode project file in the project directory") {


### PR DESCRIPTION
When generating a config file for SPM projects, we should ignore the manifest file in order to avoid non deterministic behaviours.