### PR TITLE
Display before-and-after code in the cli output when describing mutants that were applied

### DIFF
--- a/Sources/muterCore/CLICommands/RunCommand/Steps/PerformMutationTesting.swift
+++ b/Sources/muterCore/CLICommands/RunCommand/Steps/PerformMutationTesting.swift
@@ -63,7 +63,7 @@ private extension PerformMutationTesting {
             ioDelegate.backupFile(at: mutationPoint.filePath, using: state.swapFilePathsByOriginalPath)
             
             let sourceCode = state.sourceCodeByFilePath[mutationPoint.filePath]!
-            let mutantDescription = insertMutant(at: mutationPoint, within: sourceCode)
+            let mutantSnapshot = insertMutant(at: mutationPoint, within: sourceCode)
             
             let (testSuiteOutcome, testLog) = ioDelegate.runTestSuite(using: state.muterConfiguration,
                                                                       savingResultsIntoFileNamed: logFileName(for: mutationPoint))
@@ -72,7 +72,7 @@ private extension PerformMutationTesting {
 
             let outcome = MutationTestOutcome(testSuiteOutcome: testSuiteOutcome,
                                               mutationPoint: mutationPoint,
-                                              operatorDescription: mutantDescription,
+                                              mutationSnapshot: mutantSnapshot,
                                               originalProjectDirectoryUrl: state.projectDirectoryURL)
             outcomes.append(outcome)
             
@@ -96,11 +96,11 @@ private extension PerformMutationTesting {
         return .success(outcomes)
     }
     
-    func insertMutant(at mutationPoint: MutationPoint, within sourceCode: SourceFileSyntax) -> String {
-        let (mutatedSource, description) = mutationPoint.mutationOperator(sourceCode)
+    func insertMutant(at mutationPoint: MutationPoint, within sourceCode: SourceFileSyntax) -> MutationOperatorSnapshot {
+        let (mutatedSource, snapshot) = mutationPoint.mutationOperator(sourceCode)
         try! ioDelegate.writeFile(to: mutationPoint.filePath, contents: mutatedSource.description)
         
-        return description
+        return snapshot
     }
     
     func logFileName(for mutationPoint: MutationPoint) -> String {

--- a/Sources/muterCore/Extensions/StringExtensions.swift
+++ b/Sources/muterCore/Extensions/StringExtensions.swift
@@ -1,9 +1,7 @@
 import Foundation
 
 extension String {
-    func repeated(_ times: Int) -> String {
-        return (0 ..< times).reduce("") { current, _ in current + "\(self)"}
-    }
+    func repeated(_ times: Int) -> String { (0 ..< times).reduce("") { current, _ in current + "\(self)"} }
     
     func removingSubrange(_ bounds: Range<String.Index>?) -> String {
         guard let bounds = bounds else { return self }
@@ -12,7 +10,11 @@ extension String {
         return result
     }
 
-    var trimmed: String {
-        return trimmingCharacters(in: CharacterSet.whitespacesAndNewlines)
+    var trimmed: String { trimmingCharacters(in: .whitespacesAndNewlines) }
+
+    var inlined: String {
+        components(separatedBy: .newlines)
+            .map { $0.trimmed }
+            .joined(separator: " ")
     }
 }

--- a/Sources/muterCore/MutationOperators/MutationOperator.swift
+++ b/Sources/muterCore/MutationOperators/MutationOperator.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 import Foundation
 
-typealias SourceCodeTransformation = (SourceFileSyntax) -> (mutatedSource: SyntaxProtocol, description: String)
+typealias SourceCodeTransformation = (SourceFileSyntax) -> (mutatedSource: SyntaxProtocol, mutationSnapshot: MutationOperatorSnapshot)
 typealias RewriterInitializer = (MutationPosition) -> PositionSpecificRewriter
 typealias VisitorInitializer = (MuterConfiguration, SourceFileInfo) -> PositionDiscoveringVisitor
 
@@ -43,18 +43,20 @@ struct MutationOperator {
             return { source in
                 let visitor = self.rewriterVisitorPair.rewriter(position)
                 let mutatedSource = visitor.visit(source)
+                let operatorSnapshot = visitor.operatorSnapshot
                 return (
                     mutatedSource: mutatedSource,
-                    description: visitor.description
+                    mutationSnapshot: operatorSnapshot
                 )
             }
         }
     }
 }
 
-protocol PositionSpecificRewriter: CustomStringConvertible {
+protocol PositionSpecificRewriter {
     var positionToMutate: MutationPosition { get }
-    
+    var operatorSnapshot: MutationOperatorSnapshot { get set }
+
     init(positionToMutate: MutationPosition)
     
     func visit(_ node: SourceFileSyntax) -> Syntax

--- a/Sources/muterCore/MutationOperators/MutationOperatorSnapshot.swift
+++ b/Sources/muterCore/MutationOperators/MutationOperatorSnapshot.swift
@@ -1,0 +1,9 @@
+public struct MutationOperatorSnapshot: Equatable, Codable {
+    let before: String
+    let after: String
+    let description: String
+}
+
+public extension MutationOperatorSnapshot {
+    static var null: MutationOperatorSnapshot { .init(before: "", after: "", description: "") }
+}

--- a/Sources/muterCore/MutationOperators/OperatorAwareRewriter.swift
+++ b/Sources/muterCore/MutationOperators/OperatorAwareRewriter.swift
@@ -2,7 +2,7 @@ import SwiftSyntax
 
 class OperatorAwareRewriter: SyntaxRewriter, PositionSpecificRewriter {
     let positionToMutate: MutationPosition
-    private(set) var description: String = ""
+    var operatorSnapshot: MutationOperatorSnapshot = .null
     
     var oppositeOperatorMapping: [String: String] = [:]
     
@@ -16,7 +16,11 @@ class OperatorAwareRewriter: SyntaxRewriter, PositionSpecificRewriter {
                 return Syntax(token)
         }
 
-        description = "changed \(token.description.trimmed) to \(oppositeOperator)"
+        operatorSnapshot = MutationOperatorSnapshot(
+            before: token.description.trimmed,
+            after: oppositeOperator,
+            description: "changed \(token.description.trimmed) to \(oppositeOperator)"
+        )
 
         return mutated(token, using: `oppositeOperator`)
     }

--- a/Sources/muterCore/MutationOperators/RemoveSideEffectsOperator.swift
+++ b/Sources/muterCore/MutationOperators/RemoveSideEffectsOperator.swift
@@ -134,7 +134,7 @@ private extension SyntaxProtocol {
 extension RemoveSideEffectsOperator {
     class Rewriter: SyntaxRewriter, PositionSpecificRewriter {
         let positionToMutate: MutationPosition
-        let description: String = "removed line"
+        var operatorSnapshot: MutationOperatorSnapshot = .null
 
         required init(positionToMutate: MutationPosition) {
             self.positionToMutate = positionToMutate
@@ -150,6 +150,12 @@ extension RemoveSideEffectsOperator {
 
             let newCodeBlockItemList = SyntaxFactory.makeCodeBlockItemList(mutatedFunctionStatements)
             let newFunctionBody = node.body!.withStatements(newCodeBlockItemList)
+
+            operatorSnapshot = MutationOperatorSnapshot(
+                before: statementToExclude.description.trimmed.inlined,
+                after: "removed line",
+                description: "removed line"
+            )
 
             return mutated(node, with: newFunctionBody)
         }

--- a/Sources/muterCore/TestReporting/MutationTestOutcome.swift
+++ b/Sources/muterCore/TestReporting/MutationTestOutcome.swift
@@ -3,16 +3,16 @@ import Foundation
 public struct MutationTestOutcome: Equatable {
     let testSuiteOutcome: TestSuiteOutcome
     let mutationPoint: MutationPoint
-    let operatorDescription: String
+    let mutationSnapshot: MutationOperatorSnapshot
     let originalProjectPath: String
     
     public init(testSuiteOutcome: TestSuiteOutcome,
                 mutationPoint: MutationPoint,
-                operatorDescription: String,
+                mutationSnapshot: MutationOperatorSnapshot,
                 originalProjectDirectoryUrl: URL) {
         self.testSuiteOutcome = testSuiteOutcome
         self.mutationPoint = mutationPoint
-        self.operatorDescription = operatorDescription
+        self.mutationSnapshot = mutationSnapshot
         
         let splitTempFilePath = mutationPoint.filePath.split(separator: "/")
         let projectDirectoryName = originalProjectDirectoryUrl.lastPathComponent

--- a/Sources/muterCore/TestReporting/Xcode/XcodeReporter.swift
+++ b/Sources/muterCore/TestReporting/Xcode/XcodeReporter.swift
@@ -36,6 +36,6 @@ final class XcodeReporter: Reporter {
         return "\(outcome.originalProjectPath):" +
             "\(outcome.mutationPoint.position.line):\(outcome.mutationPoint.position.column): " +
             "warning: " +
-        "Your test suite did not kill this mutant: \(outcome.operatorDescription)"
+            "Your test suite did not kill this mutant: \(outcome.mutationSnapshot.description)"
     }
 }

--- a/Tests/CLICommands/RunCommandObserverSpec.swift
+++ b/Tests/CLICommands/RunCommandObserverSpec.swift
@@ -25,7 +25,7 @@ class RunCommandObserverSpec: QuickSpec {
                         name: .newMutationTestOutcomeAvailable,
                         object: MutationTestOutcome(testSuiteOutcome: .passed,
                                                     mutationPoint: MutationPoint(mutationOperatorId: .ror, filePath: "some/path", position: .firstPosition),
-                                                    operatorDescription: "some description"),
+                                                    mutationSnapshot: .null),
                         userInfo: nil
                     )
                 }

--- a/Tests/Extensions/MutationTestOutcomeExtensions.swift
+++ b/Tests/Extensions/MutationTestOutcomeExtensions.swift
@@ -4,10 +4,10 @@ import Foundation
 public extension MutationTestOutcome {
     init(testSuiteOutcome: TestSuiteOutcome,
          mutationPoint: MutationPoint,
-         operatorDescription: String = "") {
+         mutationSnapshot: MutationOperatorSnapshot = .null) {
         self.init(testSuiteOutcome: testSuiteOutcome,
                   mutationPoint: mutationPoint,
-                  operatorDescription: operatorDescription,
+                  mutationSnapshot: mutationSnapshot,
                   originalProjectDirectoryUrl: URL(fileURLWithPath: ""))
         
     }

--- a/Tests/MutationOperators/NegateConditionalsOperatorSpec.swift
+++ b/Tests/MutationOperators/NegateConditionalsOperatorSpec.swift
@@ -70,7 +70,9 @@ class NegateConditionalsOperatorSpec: QuickSpec {
 
                     let mutatedSource = rewriter.visit(sourceWithConditionalLogic.code)
                     expect(mutatedSource.description).to(equal(expectedSource.code.description))
-                    expect(rewriter.description).to(equal("changed == to !="))
+                    expect(rewriter.operatorSnapshot.before).to(equal("=="))
+                    expect(rewriter.operatorSnapshot.after).to(equal("!="))
+                    expect(rewriter.operatorSnapshot.description).to(equal("changed == to !="))
                 }
 
                 it("replaces an inequality operator with an equality operator") {
@@ -80,7 +82,9 @@ class NegateConditionalsOperatorSpec: QuickSpec {
 
                     let mutatedSource = rewriter.visit(sourceWithConditionalLogic.code)
                     expect(mutatedSource.description).to(equal(expectedSource.code.description))
-                    expect(rewriter.description).to(equal("changed != to =="))
+                    expect(rewriter.operatorSnapshot.before).to(equal("!="))
+                    expect(rewriter.operatorSnapshot.after).to(equal("=="))
+                    expect(rewriter.operatorSnapshot.description).to(equal("changed != to =="))
                 }
 
                 it("replaces a greater than or equal to operator with a less than or equal to operator") {
@@ -90,7 +94,9 @@ class NegateConditionalsOperatorSpec: QuickSpec {
 
                     let mutatedSource = rewriter.visit(sourceWithConditionalLogic.code)
                     expect(mutatedSource.description).to(equal(expectedSource.code.description))
-                    expect(rewriter.description).to(equal("changed >= to <="))
+                    expect(rewriter.operatorSnapshot.before).to(equal(">="))
+                    expect(rewriter.operatorSnapshot.after).to(equal("<="))
+                    expect(rewriter.operatorSnapshot.description).to(equal("changed >= to <="))
                 }
 
                 it("replaces a less than or equal to operator with a greater than or equal to operator") {
@@ -100,7 +106,9 @@ class NegateConditionalsOperatorSpec: QuickSpec {
 
                     let mutatedSource = rewriter.visit(sourceWithConditionalLogic.code)
                     expect(mutatedSource.description).to(equal(expectedSource.code.description))
-                    expect(rewriter.description).to(equal("changed <= to >="))
+                    expect(rewriter.operatorSnapshot.before).to(equal("<="))
+                    expect(rewriter.operatorSnapshot.after).to(equal(">="))
+                    expect(rewriter.operatorSnapshot.description).to(equal("changed <= to >="))
                 }
 
                 it("replaces a less than operator with a greater than operator") {
@@ -110,7 +118,9 @@ class NegateConditionalsOperatorSpec: QuickSpec {
 
                     let mutatedSource = rewriter.visit(sourceWithConditionalLogic.code)
                     expect(mutatedSource.description).to(equal(expectedSource.code.description))
-                    expect(rewriter.description).to(equal("changed < to >"))
+                    expect(rewriter.operatorSnapshot.before).to(equal("<"))
+                    expect(rewriter.operatorSnapshot.after).to(equal(">"))
+                    expect(rewriter.operatorSnapshot.description).to(equal("changed < to >"))
                 }
 
                 it("replaces a greater than operator with a less than operator") {
@@ -120,7 +130,9 @@ class NegateConditionalsOperatorSpec: QuickSpec {
 
                     let mutatedSource = rewriter.visit(sourceWithConditionalLogic.code)
                     expect(mutatedSource.description).to(equal(expectedSource.code.description))
-                    expect(rewriter.description).to(equal("changed > to <"))
+                    expect(rewriter.operatorSnapshot.before).to(equal(">"))
+                    expect(rewriter.operatorSnapshot.after).to(equal("<"))
+                    expect(rewriter.operatorSnapshot.description).to(equal("changed > to <"))
                 }
             }
 
@@ -130,14 +142,16 @@ class NegateConditionalsOperatorSpec: QuickSpec {
                 let expectedSource = sourceCode(fromFileAt: "\(self.mutationExamplesDirectory)/NegateConditionals/equalityOperator.swift")!
                 let transformation = MutationOperator.Id.ror.mutationOperator(for: line3Column19)
 
-                let (actualMutatedSource, actualDescription) = transformation(sourceWithConditionalLogic.code)
+                let (actualMutatedSource, actualSnapshot) = transformation(sourceWithConditionalLogic.code)
 
                 it("behaves like a NegateConditionalsOperator.Rewriter") {
                     expect(actualMutatedSource.description).to(equal(expectedSource.code.description))
                 }
 
-                it("provides a description of the operator that was applied") {
-                    expect(actualDescription).to(equal("changed == to !="))
+                it("provides a snapshot of the operator that was applied") {
+                    expect(actualSnapshot.before).to(equal("=="))
+                    expect(actualSnapshot.after).to(equal("!="))
+                    expect(actualSnapshot.description).to(equal("changed == to !="))
                 }
             }
         }

--- a/Tests/MutationTesting/PerformMutationTestingSpec.swift
+++ b/Tests/MutationTesting/PerformMutationTestingSpec.swift
@@ -62,12 +62,12 @@ class PerformMutationTestingSpec: QuickSpec {
                     let expectedTestOutcomes = [
                         MutationTestOutcome(testSuiteOutcome: .failed,
                                             mutationPoint: expectedMutationPoint,
-                                            operatorDescription: "",
+                                            mutationSnapshot: .null,
                                             originalProjectDirectoryUrl: URL(fileURLWithPath: "/project")),
                         
                         MutationTestOutcome(testSuiteOutcome: .failed,
                                             mutationPoint: expectedMutationPoint,
-                                            operatorDescription: "",
+                                            mutationSnapshot: .null,
                                             originalProjectDirectoryUrl: URL(fileURLWithPath: "/project")),
                     ]
                     
@@ -253,12 +253,12 @@ class PerformMutationTestingSpec: QuickSpec {
                     
                     let expectedBuildErrorOutcome = MutationTestOutcome(testSuiteOutcome: .buildError,
                                                                         mutationPoint: MutationPoint(mutationOperatorId: .ror, filePath: "/tmp/project/file.swift", position: .firstPosition),
-                                                                        operatorDescription: "",
+                                                                        mutationSnapshot: .null,
                                                                         originalProjectDirectoryUrl: URL(fileURLWithPath: "/project"))
                     
                     let expectedFailingOutcome = MutationTestOutcome(testSuiteOutcome: .failed,
                                                                      mutationPoint: MutationPoint(mutationOperatorId: .ror, filePath: "/tmp/project/file.swift", position: .firstPosition),
-                                                                     operatorDescription: "",
+                                                                     mutationSnapshot: .null,
                                                                      originalProjectDirectoryUrl: URL(fileURLWithPath: "/project"))
                     
                     let expectedTestOutcomes = Array(repeating: expectedBuildErrorOutcome, count: 4) + [expectedFailingOutcome]

--- a/Tests/TestReporting/MutationTestOutcomeSpec.swift
+++ b/Tests/TestReporting/MutationTestOutcomeSpec.swift
@@ -15,7 +15,7 @@ class MutationTestOutcomeSpec: QuickSpec {
                         
                         let outcome = MutationTestOutcome(testSuiteOutcome: .failed,
                                                           mutationPoint: mutationPoint,
-                                                          operatorDescription: "",
+                                                          mutationSnapshot: .null,
                                                           originalProjectDirectoryUrl: URL(fileURLWithPath: "/Users/user0/Code/ProjectDirectory"))
                         
                         expect(outcome.originalProjectPath) == "/Users/user0/Code/ProjectDirectory/Subdirectory/file.swift"
@@ -30,7 +30,7 @@ class MutationTestOutcomeSpec: QuickSpec {
                         
                         let outcome = MutationTestOutcome(testSuiteOutcome: .failed,
                                                           mutationPoint: mutationPoint,
-                                                          operatorDescription: "",
+                                                          mutationSnapshot: .null,
                                                           originalProjectDirectoryUrl: URL(fileURLWithPath: "/Users/user0/Code/ProjectDirectory"))
                         expect(outcome.originalProjectPath) == "/Users/user0/Code/ProjectDirectory/file.swift"
                         
@@ -45,7 +45,7 @@ class MutationTestOutcomeSpec: QuickSpec {
                         
                         let outcome = MutationTestOutcome(testSuiteOutcome: .failed,
                                                           mutationPoint: mutationPoint,
-                                                          operatorDescription: "",
+                                                          mutationSnapshot: .null,
                                                           originalProjectDirectoryUrl: URL(fileURLWithPath: "/Users/user0/Project Directory"))
                         expect(outcome.originalProjectPath) == "/Users/user0/Project Directory/file.swift"
                     }

--- a/Tests/TestReporting/MuterTestReportSpec.swift
+++ b/Tests/TestReporting/MuterTestReportSpec.swift
@@ -8,10 +8,17 @@ class MuterTestReportSpec: QuickSpec {
         describe("MuterTestReport") {
             context("when given a nonempty collection of MutationTestOutcomes") {
                 it("calculates all its fields as part of its initialization") {
-                    let outcomes = self.exampleMutationTestResults + [MutationTestOutcome(testSuiteOutcome: .failed,
-                                                                                          mutationPoint: MutationPoint(mutationOperatorId: .ror,
-                                                                                            filePath: "/tmp/a module.swift", position: .firstPosition),
-                                                                                          operatorDescription: "from == to !=")]
+                    let outcomes = self.exampleMutationTestResults + [MutationTestOutcome(
+                                                                        testSuiteOutcome: .failed,
+                                                                        mutationPoint: MutationPoint(mutationOperatorId: .ror,
+                                                                        filePath: "/tmp/a module.swift", position: .firstPosition),
+                                                                        mutationSnapshot: MutationOperatorSnapshot(
+                                                                            before: "==",
+                                                                            after: "!=",
+                                                                            description: "changed from == to !="
+                                                                        )
+                    )]
+
                     let report = MuterTestReport(from: outcomes)
                     expect(report.globalMutationScore).to(equal(60))
                     expect(report.totalAppliedMutationOperators).to(equal(10))

--- a/Tests/TestReporting/ReporterSpec.swift
+++ b/Tests/TestReporting/ReporterSpec.swift
@@ -11,7 +11,7 @@ class ReporterSpec: QuickSpec {
             MutationTestOutcome(
                 testSuiteOutcome: .passed,
                 mutationPoint: MutationPoint(mutationOperatorId: .ror, filePath: "/tmp/project/file3.swift", position: .firstPosition),
-                operatorDescription: "changed from != to ==",
+                mutationSnapshot: MutationOperatorSnapshot(before: "!=", after: "==", description: "changed from != to =="),
                 originalProjectDirectoryUrl: URL(string: "/user/project")!
             )
         ]
@@ -83,11 +83,11 @@ class ReporterSpec: QuickSpec {
         describe("xcode reporter") {
             let outcomes = outcomes + [MutationTestOutcome(testSuiteOutcome: .failed,
                                              mutationPoint: MutationPoint(mutationOperatorId: .ror, filePath: "/tmp/project/file4.swift", position: .firstPosition),
-                                             operatorDescription: "changed from == to !=",
+                                             mutationSnapshot: MutationOperatorSnapshot(before: "==", after: "!=", description: "changed from == to !="),
                                              originalProjectDirectoryUrl: URL(string: "/user/project")!),
                          MutationTestOutcome(testSuiteOutcome: .passed,
                                              mutationPoint: MutationPoint(mutationOperatorId: .ror, filePath: "/tmp/project/file5.swift", position: .firstPosition),
-                                             operatorDescription: "changed from == to !=",
+                                             mutationSnapshot: MutationOperatorSnapshot(before: "==", after: "!=", description: "changed from == to !="),
                                              originalProjectDirectoryUrl: URL(string: "/user/project")!)]
 
             context("with footer-only not requested") {

--- a/Tests/XCTestExtensions.swift
+++ b/Tests/XCTestExtensions.swift
@@ -131,14 +131,14 @@ public extension XCTestCase {
                 testSuiteOutcome: .passed,
                 mutationPoint: MutationPoint(
                     mutationOperatorId: .ror,
-                    filePath: "/tmp/file 4.swift",
+                    filePath: "/tmp/file 4.swift", // this file name intentionally has a space in it
                     position: .firstPosition),
                 mutationSnapshot: MutationOperatorSnapshot(
                     before: "==",
                     after: "!=",
                     description: "from == to !="
                 )
-            ) // this file name intentionally has a space in it
+            )
         ]
     }
 }

--- a/Tests/XCTestExtensions.swift
+++ b/Tests/XCTestExtensions.swift
@@ -28,18 +28,117 @@ public extension XCTestCase {
 
     var exampleMutationTestResults: [MutationTestOutcome] {
         return [
-            MutationTestOutcome(testSuiteOutcome: .failed, mutationPoint: MutationPoint(mutationOperatorId: .ror, filePath: "/tmp/file1.swift", position: .firstPosition), operatorDescription: "from == to !="),
-            MutationTestOutcome(testSuiteOutcome: .failed, mutationPoint: MutationPoint(mutationOperatorId: .ror, filePath: "/tmp/file1.swift", position: .firstPosition), operatorDescription: "from == to !="),
-            MutationTestOutcome(testSuiteOutcome: .passed, mutationPoint: MutationPoint(mutationOperatorId: .ror, filePath: "/tmp/file1.swift", position: .firstPosition), operatorDescription: "from == to !="),
+            MutationTestOutcome(
+                testSuiteOutcome: .failed,
+                mutationPoint: MutationPoint(
+                    mutationOperatorId: .ror,
+                    filePath: "/tmp/file1.swift",
+                    position: .firstPosition),
+                mutationSnapshot: MutationOperatorSnapshot(
+                    before: "==",
+                    after: "!=",
+                    description: "from == to !="
+                )
+            ),
+            MutationTestOutcome(
+                testSuiteOutcome: .failed,
+                mutationPoint: MutationPoint(
+                    mutationOperatorId: .ror,
+                    filePath: "/tmp/file1.swift",
+                    position: .firstPosition),
+                mutationSnapshot: MutationOperatorSnapshot(
+                    before: "==",
+                    after: "!=",
+                    description: "from == to !="
+                )
+            ),
+            MutationTestOutcome(
+                testSuiteOutcome: .passed,
+                mutationPoint: MutationPoint(
+                    mutationOperatorId: .ror,
+                    filePath: "/tmp/file1.swift",
+                    position: .firstPosition),
+                mutationSnapshot: MutationOperatorSnapshot(
+                    before: "==",
+                    after: "!=",
+                    description: "from == to !="
+                )
+            ),
             
-            MutationTestOutcome(testSuiteOutcome: .failed, mutationPoint: MutationPoint(mutationOperatorId: .removeSideEffects, filePath: "/tmp/file2.swift", position: .firstPosition), operatorDescription: "from == to !="),
-            MutationTestOutcome(testSuiteOutcome: .failed, mutationPoint: MutationPoint(mutationOperatorId: .removeSideEffects, filePath: "/tmp/file2.swift", position: .firstPosition), operatorDescription: "from == to !="),
+            MutationTestOutcome(
+                testSuiteOutcome: .failed,
+                mutationPoint: MutationPoint(
+                    mutationOperatorId: .removeSideEffects,
+                    filePath: "/tmp/file2.swift",
+                    position: .firstPosition),
+                mutationSnapshot: MutationOperatorSnapshot(
+                    before: "==",
+                    after: "!=",
+                    description: "from == to !="
+                )
+            ),
+            MutationTestOutcome(
+                testSuiteOutcome: .failed,
+                mutationPoint: MutationPoint(
+                    mutationOperatorId: .removeSideEffects,
+                    filePath: "/tmp/file2.swift",
+                    position: .firstPosition),
+                mutationSnapshot: MutationOperatorSnapshot(
+                    before: "==",
+                    after: "!=",
+                    description: "from == to !="
+                )
+            ),
             
-            MutationTestOutcome(testSuiteOutcome: .failed, mutationPoint: MutationPoint(mutationOperatorId: .ror, filePath: "/tmp/file3.swift", position: .firstPosition), operatorDescription: "from == to !="),
-            MutationTestOutcome(testSuiteOutcome: .passed, mutationPoint: MutationPoint(mutationOperatorId: .ror, filePath: "/tmp/file3.swift", position: .firstPosition), operatorDescription: "from == to !="),
-            MutationTestOutcome(testSuiteOutcome: .passed, mutationPoint: MutationPoint(mutationOperatorId: .ror, filePath: "/tmp/file3.swift", position: .firstPosition), operatorDescription: "from == to !="),
+            MutationTestOutcome(
+                testSuiteOutcome: .failed,
+                mutationPoint: MutationPoint(
+                    mutationOperatorId: .ror,
+                    filePath: "/tmp/file3.swift",
+                    position: .firstPosition),
+                mutationSnapshot: MutationOperatorSnapshot(
+                    before: "==",
+                    after: "!=",
+                    description: "from == to !="
+                )
+            ),
+            MutationTestOutcome(
+                testSuiteOutcome: .passed,
+                mutationPoint: MutationPoint(
+                    mutationOperatorId: .ror,
+                    filePath: "/tmp/file3.swift",
+                    position: .firstPosition),
+                mutationSnapshot: MutationOperatorSnapshot(
+                    before: "==",
+                    after: "!=",
+                    description: "from == to !="
+                )
+            ),
+            MutationTestOutcome(
+                testSuiteOutcome: .passed,
+                mutationPoint: MutationPoint(
+                    mutationOperatorId: .ror,
+                    filePath: "/tmp/file3.swift",
+                    position: .firstPosition),
+                mutationSnapshot: MutationOperatorSnapshot(
+                    before: "==",
+                    after: "!=",
+                    description: "from == to !="
+                )
+            ),
             
-            MutationTestOutcome(testSuiteOutcome: .passed, mutationPoint: MutationPoint(mutationOperatorId: .ror, filePath: "/tmp/file 4.swift", position: .firstPosition), operatorDescription: "from == to !=") // this file name intentionally has a space in it
+            MutationTestOutcome(
+                testSuiteOutcome: .passed,
+                mutationPoint: MutationPoint(
+                    mutationOperatorId: .ror,
+                    filePath: "/tmp/file 4.swift",
+                    position: .firstPosition),
+                mutationSnapshot: MutationOperatorSnapshot(
+                    before: "==",
+                    after: "!=",
+                    description: "from == to !="
+                )
+            ) // this file name intentionally has a space in it
         ]
     }
 }


### PR DESCRIPTION
Lays out the work needed to have #102 