### PR TITLE
#185 #189 process termination code

### DIFF
--- a/Sources/muterCore/MutationTesting/MutationTestingIODelegate.swift
+++ b/Sources/muterCore/MutationTesting/MutationTestingIODelegate.swift
@@ -32,7 +32,7 @@ struct MutationTestingDelegate: MutationTestingIODelegate {
             let contents = try String(contentsOf: testLogUrl)
 
             return (
-                outcome: TestSuiteOutcome.from(testLog: contents),
+                outcome: TestSuiteOutcome.from(testLog: contents, terminationStatus: process.terminationStatus),
                 testLog: contents
             )
 

--- a/Sources/muterCore/MutationTesting/MutationTestingIODelegate.swift
+++ b/Sources/muterCore/MutationTesting/MutationTestingIODelegate.swift
@@ -23,11 +23,11 @@ struct MutationTestingDelegate: MutationTestingIODelegate {
                       savingResultsIntoFileNamed fileName: String) -> (outcome: TestSuiteOutcome, testLog: String) {
         do {
             let (testProcessFileHandle, testLogUrl) = try fileHandle(for: fileName)
+            defer { testProcessFileHandle.closeFile() }
 
             let process = try testProcess(with: configuration, and: testProcessFileHandle)
             try process.run()
             process.waitUntilExit()
-            testProcessFileHandle.closeFile()
 
             let contents = try String(contentsOf: testLogUrl)
 

--- a/Sources/muterCore/TestReporting/PlainText/PlainTextReporter.swift
+++ b/Sources/muterCore/TestReporting/PlainText/PlainTextReporter.swift
@@ -112,8 +112,7 @@ final class PlainTextReporter: Reporter {
         }
     }
     
-    func mutationTestingFinished(notification: Notification) {
-        let outcomes = notification.object as! [MutationTestOutcome]
+    func mutationTestingFinished(mutationTestOutcomes outcomes: [MutationTestOutcome]) {
         printMessage(report(from: outcomes))
     }
     

--- a/Sources/muterCore/TestReporting/TestSuiteOutcome.swift
+++ b/Sources/muterCore/TestReporting/TestSuiteOutcome.swift
@@ -21,9 +21,9 @@ public enum TestSuiteOutcome: String, Codable {
 }
 
 extension TestSuiteOutcome {
-    public static func from(testLog: String) -> TestSuiteOutcome {
+    public static func from(testLog: String, terminationStatus: Int32) -> TestSuiteOutcome {
 
-        if logContainsRuntimeError(testLog) {
+        if !terminationStatusIsSuccess(terminationStatus) {
             return .runtimeError
         } else if logContainsBuildError(testLog) {
             return .buildError
@@ -53,8 +53,8 @@ extension TestSuiteOutcome {
         return try! NSRegularExpression(pattern: "with ([1-9]{1}[0-9]{0,}) failure", options: [])
     }
 
-    static private func logContainsRuntimeError(_ testLog: String) -> Bool {
-        return testLog.contains("Fatal error")
+    static private func terminationStatusIsSuccess(_ terminationStatus: Int32) -> Bool {
+        return terminationStatus == 0
     }
 
     static private func logContainsBuildError(_ testLog: String) -> Bool {

--- a/Tests/TestReporting/testSuiteResultParsingSpec.swift
+++ b/Tests/TestReporting/testSuiteResultParsingSpec.swift
@@ -9,55 +9,60 @@ class TestSuiteResultParsingSpec: QuickSpec {
             context("when a test log doesn't contain a failure, runtime error, or build error") {
                 it("returns a passed test result") {
                     var contents = loadLogFile(named: "testRunWithoutFailures_withTestSucceededFooter.log")
-                    expect(TestSuiteOutcome.from(testLog: contents)).to(equal(.passed))
+                    expect(TestSuiteOutcome.from(testLog: contents, terminationStatus: 0)).to(equal(.passed))
 
                     contents = loadLogFile(named: "testRunWithoutFailures_withTestSucceededFooter_buckOutput.log")
-                    expect(TestSuiteOutcome.from(testLog: contents)).to(equal(.passed))
+                    expect(TestSuiteOutcome.from(testLog: contents, terminationStatus: 0)).to(equal(.passed))
                 }
             }
 
             context("when a test log contains a failure") {
                 it("returns a failed test result") {
                     var contents = loadLogFile(named: "testRunWithFailures_withoutTestFailedFooter.log")
-                    expect(TestSuiteOutcome.from(testLog: contents)).to(equal(.failed))
+                    expect(TestSuiteOutcome.from(testLog: contents, terminationStatus: 0)).to(equal(.failed))
 
                     contents = loadLogFile(named: "testRunWithFailures_withTestFailedFooter.log")
-                    expect(TestSuiteOutcome.from(testLog: contents)).to(equal(.failed))
+                    expect(TestSuiteOutcome.from(testLog: contents, terminationStatus: 0)).to(equal(.failed))
 
                     contents = loadLogFile(named: "testRunWithFailures_withTestFailedFooter_singleTestFailure.log")
-                    expect(TestSuiteOutcome.from(testLog: contents)).to(equal(.failed))
+                    expect(TestSuiteOutcome.from(testLog: contents, terminationStatus: 0)).to(equal(.failed))
 
                     contents = loadLogFile(named: "testRunWithFailures_withTestFailedFooter_noTestFailureCount.log")
-                    expect(TestSuiteOutcome.from(testLog: contents)).to(equal(.failed))
+                    expect(TestSuiteOutcome.from(testLog: contents, terminationStatus: 0)).to(equal(.failed))
 
                     contents = loadLogFile(named: "testRunWithFailures_withTestFailedFooter_buckOutput.log")
-                    expect(TestSuiteOutcome.from(testLog: contents)).to(equal(.failed))
+                    expect(TestSuiteOutcome.from(testLog: contents, terminationStatus: 0)).to(equal(.failed))
                 }
             }
 
             context("when a test log contains a fatal error") {
-                it("returns a runtime error") {
+                it("does not return a runtime error if the termination status was 0") {
                     let contents = loadLogFile(named: "runtimeError_fatalError.log")
-                    expect(TestSuiteOutcome.from(testLog: contents)).to(equal(.runtimeError))
+                    expect(TestSuiteOutcome.from(testLog: contents, terminationStatus: 0)).to(equal(.passed))
                 }
+                it("returns a runtime error if the termination status was not 0") {
+                    let contents = loadLogFile(named: "runtimeError_fatalError.log")
+                    expect(TestSuiteOutcome.from(testLog: contents, terminationStatus: -127)).to(equal(.runtimeError))
+                }
+
             }
 
             context("when a test log contains a build error") {
                 it("returns a build error") {
                     var contents = loadLogFile(named: "buildError_missingProjectFile.log")
-                    expect(TestSuiteOutcome.from(testLog: contents)).to(equal(.buildError))
+                    expect(TestSuiteOutcome.from(testLog: contents, terminationStatus: 0)).to(equal(.buildError))
 
                     contents = loadLogFile(named: "buildError_runScriptStepFailed.log")
-                    expect(TestSuiteOutcome.from(testLog: contents)).to(equal(.buildError))
+                    expect(TestSuiteOutcome.from(testLog: contents, terminationStatus: 0)).to(equal(.buildError))
 
                     contents = loadLogFile(named: "buildError_invalidSwiftCode.log")
-                    expect(TestSuiteOutcome.from(testLog: contents)).to(equal(.buildError))
+                    expect(TestSuiteOutcome.from(testLog: contents, terminationStatus: 0)).to(equal(.buildError))
 
                     contents = loadLogFile(named: "buildError_withTestFailedFooter.log")
-                    expect(TestSuiteOutcome.from(testLog: contents)).to(equal(.buildError))
+                    expect(TestSuiteOutcome.from(testLog: contents, terminationStatus: 0)).to(equal(.buildError))
 
                     contents = loadLogFile(named: "buildError_buckOutput.log")
-                    expect(TestSuiteOutcome.from(testLog: contents)).to(equal(.buildError))
+                    expect(TestSuiteOutcome.from(testLog: contents, terminationStatus: 0)).to(equal(.buildError))
                 }
             }
         }


### PR DESCRIPTION
Fixes #185
Fixes #189

Look at the process termination code instead of just parsing the logs. Correctly handles a case where the logs might mention the string "fatal error" even when the tests are passing.