### PR TITLE
Use green instead of red for "mutant killed (runtime error)"

### DIFF
--- a/Sources/muterCore/TestReporting/PlainText/testReportTableGeneration.swift
+++ b/Sources/muterCore/TestReporting/PlainText/testReportTableGeneration.swift
@@ -52,9 +52,13 @@ func generateMutationScoresCLITable(from fileReports: [MuterTestReport.FileRepor
 // MARK: - Coloring Functions
 func applyMutationTestResultsColor(to rows: [CLITable.Row]) -> [CLITable.Row] {
     return rows.map {
-        let coloredValue = $0.value == TestSuiteOutcome.failed.asMutationTestOutcome ?
-            $0.value.green :
-            $0.value.red
+        let coloredValue = [
+            TestSuiteOutcome.passed.asMutationTestOutcome,
+            TestSuiteOutcome.buildError.asMutationTestOutcome
+        ].contains($0.value) ?
+            $0.value.red :
+            $0.value.green
+
         let coloredRow = CLITable.Row(value: coloredValue)
         return coloredRow
     }

--- a/Sources/muterCore/TestReporting/PlainText/testReportTableGeneration.swift
+++ b/Sources/muterCore/TestReporting/PlainText/testReportTableGeneration.swift
@@ -55,9 +55,9 @@ func applyMutationTestResultsColor(to rows: [CLITable.Row]) -> [CLITable.Row] {
         let coloredValue = [
             TestSuiteOutcome.passed.asMutationTestOutcome,
             TestSuiteOutcome.buildError.asMutationTestOutcome
-        ].contains($0.value) ?
-            $0.value.red :
-            $0.value.green
+        ].contains($0.value)
+            ? $0.value.red
+            : $0.value.green
 
         let coloredRow = CLITable.Row(value: coloredValue)
         return coloredRow


### PR DESCRIPTION
Fixes #159