### PR TITLE
Copy dylib and change dynamic shared location

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,8 @@ release:
 install: build-release
 	@install -d "$(bindir)" "$(libdir)"
 	@install "$(builddir)/release/muter" "$(bindir)"
+	@cp -r "$(builddir)/release/lib_InternalSwiftSyntaxParser.dylib" "$(bindir)/lib_InternalSwiftSyntaxParser.dylib"
+	@install_name_tool -change @rpath/lib_InternalSwiftSyntaxParser.dylib @executable_path/lib_InternalSwiftSyntaxParser.dylib "$(bindir)/muter"
 
 uninstall:
 	@rm -rf "$(bindir)/muter"

--- a/Package.swift
+++ b/Package.swift
@@ -35,7 +35,7 @@ let package = Package(
                 .product(name: "SwiftSyntax", package: "swift-syntax"),
                 .product(name: "SwiftSyntaxParser", package: "swift-syntax"),
                 .product(name: "ArgumentParser", package: "swift-argument-parser"),
-                .product(name: "Yams", package: "yams")
+                .product(name: "Yams", package: "yams"),
             ],
             path: "Sources/muterCore"
         ),


### PR DESCRIPTION
Swift Syntax is now vending its own `lib_InternalSwiftSyntaxParser.dylib`, which means we can stop relying on the version that the Xcode Toolchain vends and stop having compatibility issues.