### PR TITLE
feature/update check and simctl

### DIFF
--- a/AcceptanceTests/AcceptanceTests.swift
+++ b/AcceptanceTests/AcceptanceTests.swift
@@ -108,67 +108,15 @@ final class AcceptanceTests: XCTestCase {
     }
 
     func test_helpCommand() throws {
-        XCTAssertEqual(
-            try muterHelpOutput,
-            """
-            OVERVIEW: 🔎 Automated mutation testing for Swift 🕳️
-
-            USAGE: muter <subcommand>
-
-            OPTIONS:
-              --version               Show the version.
-              -h, --help              Show help information.
-
-            SUBCOMMANDS:
-              init                    Creates the configuration file that Muter uses
-              run (default)           Performs mutation testing for the Swift project
-                                      contained within the current directory.
-
-              See 'muter help <subcommand>' for detailed help.
-
-            """
-        )
+        try AssertSnapshot(muterHelpOutput)
     }
 
     func test_helpCommandInit() throws {
-        XCTAssertEqual(
-            try muterInitHelpOutput,
-            """
-            OVERVIEW: Creates the configuration file that Muter uses
-
-            USAGE: muter init
-
-            OPTIONS:
-              --version               Show the version.
-              -h, --help              Show help information.
-
-
-            """
-        )
+        try AssertSnapshot(muterInitHelpOutput)
     }
 
     func test_helpCommandRun() throws {
-        XCTAssertEqual(
-            try muterRunHelpOutput,
-            """
-            OVERVIEW: Performs mutation testing for the Swift project contained within the
-            current directory.
-
-            USAGE: muter run [--files-to-mutate <files-to-mutate> ...] [--format <format>] [--skip-coverage] [--output <output>]
-
-            OPTIONS:
-              --files-to-mutate <files-to-mutate>
-                                      Only mutate a given list of source code files.
-              -f, --format <format>   The report format for muter: plain, json, html, xcode
-              --skip-coverage         Skips the step in which Muter runs your project in
-                                      order to filter out files without coverage.
-              -o, --output <output>   Output file for the report to be saved.
-              --version               Show the version.
-              -h, --help              Show help information.
-
-
-            """
-        )
+        try AssertSnapshot(muterRunHelpOutput)
     }
 }
 

--- a/AcceptanceTests/__Snapshots__/AcceptanceTests/test_helpCommand.1.txt
+++ b/AcceptanceTests/__Snapshots__/AcceptanceTests/test_helpCommand.1.txt
@@ -1,0 +1,14 @@
+OVERVIEW: 🔎 Automated mutation testing for Swift 🕳️
+
+USAGE: muter <subcommand>
+
+OPTIONS:
+  --version               Show the version.
+  -h, --help              Show help information.
+
+SUBCOMMANDS:
+  init                    Creates the configuration file that Muter uses
+  run (default)           Performs mutation testing for the Swift project
+                          contained within the current directory.
+
+  See 'muter help <subcommand>' for detailed help.

--- a/AcceptanceTests/__Snapshots__/AcceptanceTests/test_helpCommandInit.1.txt
+++ b/AcceptanceTests/__Snapshots__/AcceptanceTests/test_helpCommandInit.1.txt
@@ -1,0 +1,8 @@
+OVERVIEW: Creates the configuration file that Muter uses
+
+USAGE: muter init
+
+OPTIONS:
+  --version               Show the version.
+  -h, --help              Show help information.
+

--- a/AcceptanceTests/__Snapshots__/AcceptanceTests/test_helpCommandRun.1.txt
+++ b/AcceptanceTests/__Snapshots__/AcceptanceTests/test_helpCommandRun.1.txt
@@ -1,0 +1,17 @@
+OVERVIEW: Performs mutation testing for the Swift project contained within the
+current directory.
+
+USAGE: muter run [--files-to-mutate <files-to-mutate> ...] [--format <format>] [--skip-coverage] [--output <output>] [--skip-update-check]
+
+OPTIONS:
+  --files-to-mutate <files-to-mutate>
+                          Only mutate a given list of source code files.
+  -f, --format <format>   The report format for muter: plain, json, html, xcode
+  --skip-coverage         Skips the step in which Muter runs your project in
+                          order to filter out files without coverage.
+  -o, --output <output>   Output file for the report to be saved.
+  --skip-update-check     Skips the step in which Muter checks for newer
+                          versions.
+  --version               Show the version.
+  -h, --help              Show help information.
+

--- a/AcceptanceTests/runAcceptanceTests.sh
+++ b/AcceptanceTests/runAcceptanceTests.sh
@@ -23,7 +23,7 @@ echo " > Creating a configuration file..."
 cp ./muter.conf.yml "$samplesdir"/created_iOS_config.yml
 
 echo " > Running in CLI mode..."
-"$muterdir"/muter --skip-coverage > "$samplesdir"/muters_output.txt
+"$muterdir"/muter --skip-coverage --skip-update-check > "$samplesdir"/muters_output.txt
 echo " > Copying logs..."
 cp -R ./muter_logs "$samplesdir"/
 rm -rf ./muter_logs
@@ -33,11 +33,11 @@ echo " > Running with coverage"
 rm -rf ./muter_logs
 
 echo " > Running in Xcode mode..."
-"$muterdir"/muter --format xcode --skip-coverage > "$samplesdir"/muters_xcode_output.txt
+"$muterdir"/muter --format xcode --skip-coverage --skip-update-check > "$samplesdir"/muters_xcode_output.txt
 rm -rf ./muter_logs # don't pollute the staging area
 
 echo " > Running with --filesToMutate flag"
-"$muterdir"/muter --skip-coverage --files-to-mutate "/ExampleApp/Module.swift" > "$samplesdir"/muters_files_to_mutate_output.txt
+"$muterdir"/muter --skip-coverage --skip-update-check --files-to-mutate "/ExampleApp/Module.swift" > "$samplesdir"/muters_files_to_mutate_output.txt
 rm -rf ./muter_logs # don't pollute the staging area
 
 rm muter.conf.yml # cleanup the created configuration file for the next test run
@@ -58,14 +58,14 @@ echo "Running Muter on an empty example codebase..."
 cd ./Repositories/EmptyExampleApp
 
 echo " > Running in CLI mode..."
-"$muterdir"/muter --skip-coverage > "$samplesdir"/muters_empty_state_output.txt
+"$muterdir"/muter --skip-coverage --skip-update-check > "$samplesdir"/muters_empty_state_output.txt
 cd ../..
 
 echo "Running Muter on an example test suite that fails..."
 cd ./Repositories/ProjectWithFailures
 
 echo " > Running in CLI mode..."
-"$muterdir"/muter --skip-coverage > "$samplesdir"/muters_aborted_testing_output.txt
+"$muterdir"/muter --skip-coverage --skip-update-check > "$samplesdir"/muters_aborted_testing_output.txt
 rm -rf ./muter_logs # don't pollute the staging area
 
 cd ../..

--- a/Package.resolved
+++ b/Package.resolved
@@ -73,6 +73,15 @@
       }
     },
     {
+      "identity" : "version",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/mxcl/Version.git",
+      "state" : {
+        "revision" : "1fe824b80d89201652e7eca7c9252269a1d85e25",
+        "version" : "2.0.1"
+      }
+    },
+    {
       "identity" : "yams",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/jpsim/Yams.git",

--- a/Package.swift
+++ b/Package.swift
@@ -20,7 +20,8 @@ let package = Package(
         .package(url: "https://github.com/johnsundell/plot.git", from: "0.14.0"),
         .package(url: "https://github.com/krzysztofzablocki/Difference.git", from: "1.0.2"),
         .package(url: "https://github.com/jpsim/Yams.git", from: "5.0.5"),
-        .package(url: "https://github.com/pointfreeco/swift-snapshot-testing.git", from: "1.11.0")
+        .package(url: "https://github.com/pointfreeco/swift-snapshot-testing.git", from: "1.11.0"),
+        .package(url: "https://github.com/mxcl/Version.git", from: "2.0.1")
     ],
     targets: [
         .executableTarget(
@@ -38,6 +39,7 @@ let package = Package(
                 .product(name: "SwiftSyntaxParser", package: "swift-syntax"),
                 .product(name: "ArgumentParser", package: "swift-argument-parser"),
                 .product(name: "Yams", package: "yams"),
+                .product(name: "Version", package: "Version")
             ],
             path: "Sources/muterCore"
         ),
@@ -59,7 +61,11 @@ let package = Package(
                 "TestingExtensions"
             ],
             path: "Tests",
-            exclude: ["fixtures", "Extensions"]
+            exclude: [
+                "__Snapshots__",
+                "fixtures",
+                "Extensions"
+            ]
         ),
         .testTarget(
             name: "muterAcceptanceTests",
@@ -69,7 +75,10 @@ let package = Package(
                 .product(name: "SnapshotTesting", package: "swift-snapshot-testing"),
             ],
             path: "AcceptanceTests",
-            exclude: ["runAcceptanceTests.sh"]
+            exclude: [
+                "__Snapshots__",
+                "runAcceptanceTests.sh"
+            ]
         ),
         .testTarget(
             name: "muterRegressionTests",
@@ -79,7 +88,10 @@ let package = Package(
                 .product(name: "SnapshotTesting", package: "swift-snapshot-testing"),
             ],
             path: "RegressionTests",
-            exclude: ["__Snapshots__", "runRegressionTests.sh"]
+            exclude: [
+                "__Snapshots__",
+                "runRegressionTests.sh"
+            ]
         )
     ]
 )

--- a/README.md
+++ b/README.md
@@ -194,7 +194,11 @@ Muter defaults to run when you don't specify any subcommands
 **Available Flags**
 
 ```
---files-to-mutate    Only mutate a given list of source code files (Supports glob expressions like Sources/**/*.swift)
+--files-to-mutate           Only mutate a given list of source code files (Supports glob expressions like Sources/**/*.swift)
+-f, --format <format>       The report format for muter: plain, json, html, xcode
+--skip-coverage             Skips the step in which Muter runs your project in order to filter out files without coverage.
+-o, --output <output>       Output file for the report to be saved.
+--skip-update-check         Skips the step in which Muter checks for newer versions.
 ```
 
 **Available Report Formats**

--- a/RegressionTests/runRegressionTests.sh
+++ b/RegressionTests/runRegressionTests.sh
@@ -10,21 +10,21 @@ mkdir -p ./RegressionTests/samples
 
 echo "Running Regression Test on BonMot..."
 cd ./Repositories/BonMot
-"$muterdir"/muter --format json --output muterReport.json
+"$muterdir"/muter --skip-update-check --format json --output muterReport.json
 
 cp ./muterReport.json "$samplesdir"/bonmot_regression_test_output.json
 cd ../..
 
 echo "Running Regression Test on Parser Combinator..."
 cd ./Repositories/FFCParserCombinator
-"$muterdir"/muter --skip-coverage --format json --output muterReport.json
+"$muterdir"/muter --skip-coverage --skip-update-check --format json --output muterReport.json
 cp ./muterReport.json "$samplesdir"/parsercombinator_regression_test_output.json
 cd ../..
 
 echo "Running Regression Test on Project With Concurrency..."
 cd ./Repositories/ProjectWithConcurrency
 swift package generate-xcodeproj
-"$muterdir"/muter --skip-coverage --format json --output muterReport.json
+"$muterdir"/muter --skip-coverage --skip-update-check --format json --output muterReport.json
 cp ./muterReport.json "$samplesdir"/projectwithconcurrency_test_output.json
 cd ../..
 

--- a/Sources/muterCore/CLICommands/RunCommand/Run.swift
+++ b/Sources/muterCore/CLICommands/RunCommand/Run.swift
@@ -34,6 +34,12 @@ public struct Run: ParsableCommand {
     )
     var reportURL: URL?
 
+    @Flag(
+        name: [.customLong("skip-update-check")],
+        help: "Skips the step in which Muter checks for newer versions."
+    )
+    var skipUpdateCheck: Bool = false
+
     public init() {}
 
     public func run() throws {
@@ -41,7 +47,8 @@ public struct Run: ParsableCommand {
             filesToMutate: filesToMutate,
             reportFormat: reportFormat,
             reportURL: reportURL,
-            skipCoverage: skipCoverage
+            skipCoverage: skipCoverage,
+            skipUpdateCheck: skipUpdateCheck
         )
 
         _ = RunCommandObserver(
@@ -61,7 +68,7 @@ public struct Run: ParsableCommand {
 
                 ⚠️ ⚠️ ⚠️ ⚠️ ⚠️  See the Muter error log above this line  ⚠️ ⚠️ ⚠️ ⚠️ ⚠️
 
-                If you feel like this is a bug, or want help figuring out what could be happening, please open an issue at
+                If you think this is a bug, or want help figuring out what could be happening, please open an issue at
                 https://github.com/muter-mutation-testing/muter/issues
                 """
             )

--- a/Sources/muterCore/CLICommands/RunCommand/RunCommandHandler.swift
+++ b/Sources/muterCore/CLICommands/RunCommand/RunCommandHandler.swift
@@ -31,7 +31,7 @@ private extension RunCommandHandler {
     private static let defaultSteps: [RunCommandStep] = [
         LoadConfiguration(),
         CreateTempDirectoryURL(),
-        RemoveProjectFromPreviousRun(),
+        PreviousRunCleanUp(),
         CopyProjectToTempDirectory(),
         DiscoverProjectCoverage(),
         DiscoverSourceFiles(),

--- a/Sources/muterCore/CLICommands/RunCommand/RunCommandHandler.swift
+++ b/Sources/muterCore/CLICommands/RunCommand/RunCommandHandler.swift
@@ -29,6 +29,7 @@ final class RunCommandHandler {
 
 private extension RunCommandHandler {
     private static let defaultSteps: [RunCommandStep] = [
+        UpdateCheck(),
         LoadConfiguration(),
         CreateTempDirectoryURL(),
         PreviousRunCleanUp(),
@@ -47,6 +48,9 @@ private extension [RunCommandStep] {
     func filter(with options: RunOptions) -> [Element] {
         exclude {
             options.skipCoverage && $0 is DiscoverProjectCoverage
+        }
+        .exclude {
+            options.skipUpdateCheck && $0 is UpdateCheck
         }
     }
 }

--- a/Sources/muterCore/CLICommands/RunCommand/RunCommandObserver.swift
+++ b/Sources/muterCore/CLICommands/RunCommand/RunCommandObserver.swift
@@ -7,6 +7,9 @@ import SwiftSyntax
 extension Notification.Name {
     static let muterLaunched = Notification.Name("muterLaunched")
 
+    static let updateCheckStarted = Notification.Name("updateCheckStarted")
+    static let updateCheckFinished = Notification.Name("updateCheckFinished")
+
     static let projectCopyStarted = Notification.Name("projectCopyStarted")
     static let projectCopyFinished = Notification.Name("projectCopyFinished")
 
@@ -46,6 +49,9 @@ final class RunCommandObserver {
         [
             (name: .muterLaunched, handler: handleMuterLaunched),
 
+            (name: .updateCheckStarted, handler: handleUpdateCheckStarted),
+            (name: .updateCheckFinished, handler: handleUpdateCheckFinished),
+
             (name: .projectCopyStarted, handler: handleProjectCopyStarted),
             (name: .projectCopyFinished, handler: handleProjectCopyFinished),
 
@@ -84,7 +90,6 @@ final class RunCommandObserver {
                 using: handler
             )
         }
-
     }
 
     deinit {
@@ -95,6 +100,14 @@ final class RunCommandObserver {
 extension RunCommandObserver {
     func handleMuterLaunched(notification: Notification) {
         logger.launched()
+    }
+
+    func handleUpdateCheckStarted(notification: Notification) {
+        logger.updateCheckStarted()
+    }
+
+    func handleUpdateCheckFinished(notification: Notification) {
+        logger.updateCheckFinished(newVersion: notification.object as? String)
     }
 
     func handleProjectCopyStarted(notification: Notification) {

--- a/Sources/muterCore/CLICommands/RunCommand/RunOptions.swift
+++ b/Sources/muterCore/CLICommands/RunCommand/RunOptions.swift
@@ -6,6 +6,7 @@ struct RunOptions {
     let reportOptions: ReportOptions
     let filesToMutate: [String]
     let skipCoverage: Bool
+    let skipUpdateCheck: Bool
 
     @Dependency(\.logger)
     private var logger: Logger
@@ -14,10 +15,13 @@ struct RunOptions {
         filesToMutate: [String],
         reportFormat: ReportFormat,
         reportURL: URL?,
-        skipCoverage: Bool
+        skipCoverage: Bool,
+        skipUpdateCheck: Bool
     ) {
         self.filesToMutate = filesToMutate
         self.skipCoverage = skipCoverage
+        self.skipUpdateCheck = skipUpdateCheck
+
         reportOptions = ReportOptions(
             reporter: reportFormat.reporter,
             path: reportPath(reportURL)

--- a/Sources/muterCore/MuterRunSteps/PreviousRunCleanUp.swift
+++ b/Sources/muterCore/MuterRunSteps/PreviousRunCleanUp.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-struct RemoveProjectFromPreviousRun: RunCommandStep {
+struct PreviousRunCleanUp: RunCommandStep {
     @Dependency(\.fileManager)
     private var fileManager: FileSystemManager
 

--- a/Sources/muterCore/MuterRunSteps/UpdateCheck.swift
+++ b/Sources/muterCore/MuterRunSteps/UpdateCheck.swift
@@ -1,0 +1,67 @@
+import Foundation
+import Version
+
+typealias MuterVersionFecher = (URL, Data.ReadingOptions) throws -> Data
+
+private let url = "https://api.github.com/repos/muter-mutation-testing/muter/releases?per_page=1"
+
+struct UpdateCheck: RunCommandStep {
+    @Dependency(\.notificationCenter)
+    private var notificationCenter: NotificationCenter
+    private let versionFetcher: MuterVersionFecher
+    private let currentVersion: Version
+
+    init(
+        versionFetcher: @escaping MuterVersionFecher = Data.init(contentsOf:options:),
+        currentVersion: Version = Version(tolerant: version)!
+    ) {
+        self.versionFetcher = versionFetcher
+        self.currentVersion = currentVersion
+    }
+
+    func run(with state: AnyRunCommandState) -> Result<[RunCommandState.Change], MuterError> {
+        guard let releaseURL = URL(string: url) else {
+            return .success([])
+        }
+
+        notificationCenter.post(name: .updateCheckStarted, object: nil)
+
+        var newVersion: String?
+
+        do {
+            let data = try versionFetcher(releaseURL, [])
+            let latestVersion = try muterLatestVersion(data)
+
+            if currentVersion < latestVersion {
+                newVersion = latestVersion.description
+            }
+        } catch {}
+
+        notificationCenter.post(name: .updateCheckFinished, object: newVersion)
+
+        return .success([])
+    }
+
+    private func muterLatestVersion(_ data: Data) throws -> Version {
+        guard let release = try? JSONDecoder().decode([MuterVersion].self, from: data),
+              let muterVersion = release.first,
+              let latestVersion = Version(tolerant: muterVersion.number)
+        else {
+            throw UpdateCheckError.parsingError
+        }
+
+        return latestVersion
+    }
+}
+
+private enum UpdateCheckError: Error {
+    case parsingError
+}
+
+struct MuterVersion: Decodable {
+    let number: String
+
+    private enum CodingKeys: String, CodingKey {
+        case number = "tag_name"
+    }
+}

--- a/Sources/muterCore/TestReporting/Logger.swift
+++ b/Sources/muterCore/TestReporting/Logger.swift
@@ -45,6 +45,18 @@ final class Logger {
         )
     }
 
+    func updateCheckStarted() {
+        print("🔎 Checking for new versions...")
+    }
+
+    func updateCheckFinished(newVersion: String?) {
+        if let newVersion {
+            print("🎉 New version \(newVersion) available!")
+        } else {
+            print("✅ You are already using the latest of Muter")
+        }
+    }
+
     func projectCopyStarted() {
         print("Copying your project to a temporary directory for testing...")
     }

--- a/Tests/CLICommands/RunCommandHandlerTests.swift
+++ b/Tests/CLICommands/RunCommandHandlerTests.swift
@@ -80,39 +80,47 @@ final class RunCommandHandlerTests: MuterTestCase {
         stepSpy3.resultToReturn = .success([])
     }
 
+    func test_allSteps() {
+        sut = RunCommandHandler(options: .make())
+
+        XCTAssertEqual(sut.steps.count, 12)
+
+        XCTAssertTypeEqual(sut.steps[safe: 0], UpdateCheck.self)
+        XCTAssertTypeEqual(sut.steps[safe: 1], LoadConfiguration.self)
+        XCTAssertTypeEqual(sut.steps[safe: 2], CreateTempDirectoryURL.self)
+        XCTAssertTypeEqual(sut.steps[safe: 3], PreviousRunCleanUp.self)
+        XCTAssertTypeEqual(sut.steps[safe: 4], CopyProjectToTempDirectory.self)
+        XCTAssertTypeEqual(sut.steps[safe: 5], DiscoverProjectCoverage.self)
+        XCTAssertTypeEqual(sut.steps[safe: 6], DiscoverSourceFiles.self)
+        XCTAssertTypeEqual(sut.steps[safe: 7], DiscoverMutationPoints.self)
+        XCTAssertTypeEqual(sut.steps[safe: 8], GenerateSwapFilePaths.self)
+        XCTAssertTypeEqual(sut.steps[safe: 9], ApplySchemata.self)
+        XCTAssertTypeEqual(sut.steps[safe: 10], BuildForTesting.self)
+        XCTAssertTypeEqual(sut.steps[safe: 11], PerformMutationTesting.self)
+    }
+
     func test_steps_whenSkipsCoverage() {
         sut = RunCommandHandler(options: .make(skipCoverage: true))
 
-        XCTAssertEqual(sut.steps.count, 10)
-
-        XCTAssertTypeEqual(sut.steps[safe: 0], LoadConfiguration.self)
-        XCTAssertTypeEqual(sut.steps[safe: 1], CreateTempDirectoryURL.self)
-        XCTAssertTypeEqual(sut.steps[safe: 1], CreateTempDirectoryURL.self)
-        XCTAssertTypeEqual(sut.steps[safe: 2], PreviousRunCleanUp.self)
-        XCTAssertTypeEqual(sut.steps[safe: 3], CopyProjectToTempDirectory.self)
-        XCTAssertTypeEqual(sut.steps[safe: 4], DiscoverSourceFiles.self)
-        XCTAssertTypeEqual(sut.steps[safe: 5], DiscoverMutationPoints.self)
-        XCTAssertTypeEqual(sut.steps[safe: 6], GenerateSwapFilePaths.self)
-        XCTAssertTypeEqual(sut.steps[safe: 7], ApplySchemata.self)
-        XCTAssertTypeEqual(sut.steps[safe: 8], BuildForTesting.self)
-        XCTAssertTypeEqual(sut.steps[safe: 9], PerformMutationTesting.self)
+        assertStepsDoesNotContain(sut.steps, DiscoverProjectCoverage.self)
     }
 
-    func test_steps_whenDontSkipCoverage() {
-        sut = RunCommandHandler(options: .make(skipCoverage: false))
+    func test_steps_whenSkipUpdateCheck() {
+        sut = RunCommandHandler(options: .make(skipUpdateCheck: true))
 
-        XCTAssertEqual(sut.steps.count, 11)
+        assertStepsDoesNotContain(sut.steps, UpdateCheck.self)
+    }
 
-        XCTAssertTypeEqual(sut.steps[safe: 0], LoadConfiguration.self)
-        XCTAssertTypeEqual(sut.steps[safe: 1], CreateTempDirectoryURL.self)
-        XCTAssertTypeEqual(sut.steps[safe: 2], PreviousRunCleanUp.self)
-        XCTAssertTypeEqual(sut.steps[safe: 3], CopyProjectToTempDirectory.self)
-        XCTAssertTypeEqual(sut.steps[safe: 4], DiscoverProjectCoverage.self)
-        XCTAssertTypeEqual(sut.steps[safe: 5], DiscoverSourceFiles.self)
-        XCTAssertTypeEqual(sut.steps[safe: 6], DiscoverMutationPoints.self)
-        XCTAssertTypeEqual(sut.steps[safe: 7], GenerateSwapFilePaths.self)
-        XCTAssertTypeEqual(sut.steps[safe: 8], ApplySchemata.self)
-        XCTAssertTypeEqual(sut.steps[safe: 9], BuildForTesting.self)
-        XCTAssertTypeEqual(sut.steps[safe: 10], PerformMutationTesting.self)
+    private func assertStepsDoesNotContain(
+        _ steps: [RunCommandStep],
+        _ step: RunCommandStep.Type,
+        file: StaticString = #file,
+        line: UInt = #line
+    ) {
+        XCTAssertFalse(
+            steps.contains { type(of: $0) == step },
+            file: file,
+            line: line
+        )
     }
 }

--- a/Tests/CLICommands/RunCommandHandlerTests.swift
+++ b/Tests/CLICommands/RunCommandHandlerTests.swift
@@ -88,7 +88,7 @@ final class RunCommandHandlerTests: MuterTestCase {
         XCTAssertTypeEqual(sut.steps[safe: 0], LoadConfiguration.self)
         XCTAssertTypeEqual(sut.steps[safe: 1], CreateTempDirectoryURL.self)
         XCTAssertTypeEqual(sut.steps[safe: 1], CreateTempDirectoryURL.self)
-        XCTAssertTypeEqual(sut.steps[safe: 2], RemoveProjectFromPreviousRun.self)
+        XCTAssertTypeEqual(sut.steps[safe: 2], PreviousRunCleanUp.self)
         XCTAssertTypeEqual(sut.steps[safe: 3], CopyProjectToTempDirectory.self)
         XCTAssertTypeEqual(sut.steps[safe: 4], DiscoverSourceFiles.self)
         XCTAssertTypeEqual(sut.steps[safe: 5], DiscoverMutationPoints.self)
@@ -105,7 +105,7 @@ final class RunCommandHandlerTests: MuterTestCase {
 
         XCTAssertTypeEqual(sut.steps[safe: 0], LoadConfiguration.self)
         XCTAssertTypeEqual(sut.steps[safe: 1], CreateTempDirectoryURL.self)
-        XCTAssertTypeEqual(sut.steps[safe: 2], RemoveProjectFromPreviousRun.self)
+        XCTAssertTypeEqual(sut.steps[safe: 2], PreviousRunCleanUp.self)
         XCTAssertTypeEqual(sut.steps[safe: 3], CopyProjectToTempDirectory.self)
         XCTAssertTypeEqual(sut.steps[safe: 4], DiscoverProjectCoverage.self)
         XCTAssertTypeEqual(sut.steps[safe: 5], DiscoverSourceFiles.self)

--- a/Tests/CLICommands/Steps/PreviousRunCleanUpTests.swift
+++ b/Tests/CLICommands/Steps/PreviousRunCleanUpTests.swift
@@ -5,9 +5,9 @@ enum RemoveTempDirectorySpecError: String, Error {
     case stub
 }
 
-final class RemoveProjectFromPreviousRunTests: MuterTestCase {
+final class PreviousRunCleanUpTests: MuterTestCase {
     private var state = RunCommandState()
-    private lazy var sut = RemoveProjectFromPreviousRun()
+    private lazy var sut = PreviousRunCleanUp()
 
     func test_removeTempDirectorySucceeds() throws {
         fileManager.fileExistsToReturn = [true]

--- a/Tests/CLICommands/Steps/UpdateCheckTests.swift
+++ b/Tests/CLICommands/Steps/UpdateCheckTests.swift
@@ -92,7 +92,6 @@ final class UpdateCheckTests: MuterTestCase {
             }
          ]
         """.data(using: .utf8) ?? .init()
-
     }
 }
 

--- a/Tests/CLICommands/Steps/UpdateCheckTests.swift
+++ b/Tests/CLICommands/Steps/UpdateCheckTests.swift
@@ -1,0 +1,114 @@
+@testable import muterCore
+import TestingExtensions
+import Version
+import XCTest
+
+final class UpdateCheckTests: MuterTestCase {
+    private let versionFetcher = VersionFetcherSpy()
+    private let currentVersion = Version(1, 0, 0)
+    private let state = RunCommandState()
+
+    private lazy var sut = UpdateCheck(
+        versionFetcher: versionFetcher.fetch,
+        currentVersion: currentVersion
+    )
+
+    func test_notificationStarted() {
+        let expect = expectation(
+            forNotification: .updateCheckStarted,
+            object: nil,
+            notificationCenter: notificationCenter
+        )
+
+        _ = sut.run(with: state)
+
+        wait(for: [expect], timeout: 2)
+    }
+
+    func test_url() {
+        _ = sut.run(with: state)
+
+        XCTAssertEqual(versionFetcher.methodCalls.count, 1)
+        XCTAssertEqual(versionFetcher.optionsPassed, [])
+        XCTAssertEqual(
+            versionFetcher.urlPassed?.absoluteString,
+            "https://api.github.com/repos/muter-mutation-testing/muter/releases?per_page=1"
+        )
+    }
+
+    func test_parse() throws {
+        versionFetcher.dataToBeReturned = createReleaseJsonData()
+
+        let result = try sut.run(with: state).get()
+
+        XCTAssertEqual(result, [])
+    }
+
+    func test_newVersionAvailable() {
+        versionFetcher.dataToBeReturned = createReleaseJsonData("9.9.9")
+
+        var newVersion: String?
+        let expect = expectation(
+            forNotification: .updateCheckFinished,
+            object: nil,
+            notificationCenter: notificationCenter
+        ) { notification in
+            newVersion = notification.object as? String
+            return true
+        }
+
+        _ = sut.run(with: state)
+
+        wait(for: [expect], timeout: 2)
+
+        XCTAssertEqual(newVersion, "9.9.9")
+    }
+
+    func test_noNewVersion() {
+        versionFetcher.dataToBeReturned = createReleaseJsonData("0.0.0")
+
+        var newVersion: String?
+        let expect = expectation(
+            forNotification: .updateCheckFinished,
+            object: nil,
+            notificationCenter: notificationCenter
+        ) { notification in
+            newVersion = notification.object as? String
+            return true
+        }
+
+        _ = sut.run(with: state)
+
+        wait(for: [expect], timeout: 2)
+
+        XCTAssertNil(newVersion)
+    }
+
+    private func createReleaseJsonData(_ version: String = "") -> Data {
+        """
+         [
+            {
+                 "tag_name": "\(version)"
+            }
+         ]
+        """.data(using: .utf8) ?? .init()
+
+    }
+}
+
+private class VersionFetcherSpy: Spy {
+    var methodCalls: [String] = []
+
+    private(set) var urlPassed: URL?
+    private(set) var optionsPassed: Data.ReadingOptions?
+    var dataToBeReturned = Data()
+
+    func fetch(_ url: URL, _ options: Data.ReadingOptions) throws -> Data {
+        methodCalls.append(#function)
+
+        urlPassed = url
+        optionsPassed = options
+
+        return dataToBeReturned
+    }
+}

--- a/Tests/TestDoubles/Fixtures.swift
+++ b/Tests/TestDoubles/Fixtures.swift
@@ -167,13 +167,15 @@ extension RunOptions {
         filesToMutate: [String] = [],
         reportFormat: ReportFormat = .plain,
         reportURL: URL? = nil,
-        skipCoverage: Bool = false
+        skipCoverage: Bool = false,
+        skipUpdateCheck: Bool = false
     ) -> Self {
         .init(
             filesToMutate: filesToMutate,
             reportFormat: reportFormat,
             reportURL: reportURL,
-            skipCoverage: skipCoverage
+            skipCoverage: skipCoverage,
+            skipUpdateCheck: skipUpdateCheck
         )
     }
 }


### PR DESCRIPTION
- Add a step to check for the newest version.
- Use `simctl` to fetch a valid sim name to the muter config generator.