### PR TITLE
Enhance file exclusion by ignoring Package.swift and make it more folder aware

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,20 +131,22 @@ Should you need to modify any of the options, you can use the list below to unde
 ### [Configuration Options](#configuration-options)
 - `executable` - the absolute path to the program which can run your test suite (like `xcodebuild`, `swift`, `fastlane`, `make`, etc.)
 - `arguments` - any command line arguments the executable needs to run your test suite
-- `exclude` - a list of paths, file extensions, or names you want Muter to ignore. By default, Muter ignores `Package.swift` files, all non-Swift files, and any files or paths containing the following phrases:
-    * `.build`
-    * `.framework`
-    * `.swiftdep`
-    * `.swiftmodule`
-    * `Build`
-    * `Carthage`
-    * `muter_tmp`
-    * `Pods`
-    * `Spec`
-    * `Test`
+- `exclude` - a list of paths, file extensions, or names you want Muter to ignore. By default, Muter ignores all non-Swift files, and any paths containing the following phrases:
+    * `/.build/`
+    * `/.framework/`
+    * `/.swiftdep/`
+    * `/.swiftmodule/`
+    * `/Build/`
+    * `/Carthage/`
+    * `/muter_tmp/`
+    * `/Pods/`
+    * `/Spec/`
+    * `/Tests/`
+    * `Tests.swift`
+    * `/Package.swift`
 
     The `exclude` option is optional.
-
+    
     **NOTE**: Muter uses a substring match to determine if a file should be excluded from mutation testing. You should not use glob expressions (like `**/*Model.swift`) or regex.
 
 - `excludeCalls` - a list of function names you want Muter to ignore in the [Remove Side Effects](https://github.com/muter-mutation-testing/muter/blob/master/Docs/mutation_operators.md) mutation operator, such as custom logging functions. Mutants in which these functions aren't called will not be created (note that mutations within the functions themselves are *not* skipped, only calls to those functions).

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ Should you need to modify any of the options, you can use the list below to unde
 ### [Configuration Options](#configuration-options)
 - `executable` - the absolute path to the program which can run your test suite (like `xcodebuild`, `swift`, `fastlane`, `make`, etc.)
 - `arguments` - any command line arguments the executable needs to run your test suite
-- `exclude` - a list of paths, file extensions, or names you want Muter to ignore. By default, Muter ignores all non-Swift files, and any files or paths containing the following phrases:
+- `exclude` - a list of paths, file extensions, or names you want Muter to ignore. By default, Muter ignores `Package.swift` files, all non-Swift files, and any files or paths containing the following phrases:
     * `.build`
     * `.framework`
     * `.swiftdep`

--- a/Sources/muterCore/MuterRunSteps/DiscoverSourceFiles.swift
+++ b/Sources/muterCore/MuterRunSteps/DiscoverSourceFiles.swift
@@ -46,16 +46,17 @@ struct DiscoverSourceFiles: RunCommandStep {
 private extension DiscoverSourceFiles {
     private var defaultExcludeList: [FilePath] {
         [
-            ".swiftpm",
-            ".build",
-            "Build",
-            "Carthage",
-            "muter_tmp",
-            "Pods",
-            "Spec",
-            "Test",
-            "fastlane",
-            "Package.swift"
+            "/.swiftpm/",
+            "/.build/",
+            "/Build/",
+            "/Carthage/",
+            "/muter_tmp/",
+            "/Pods/",
+            "/Spec/",
+            "/Tests/",
+            "Tests.swift",
+            "/fastlane/",
+            "/Package.swift",
         ]
     }
 
@@ -65,8 +66,9 @@ private extension DiscoverSourceFiles {
         ignoringFilesWithoutCoverage filesWithoutCoverage: [FilePath]
     ) -> [FilePath] {
         let excludeList = providedExcludeList + defaultExcludeList
-        let subpaths = fileManager.subpaths(atPath: rootPath) ?? []
-
+        let subpaths = (fileManager.subpaths(atPath: rootPath) ?? [])
+            .map { "./" + $0 }
+        
         return includeSwiftFiles(
             from: subpaths
                 .exclude(
@@ -75,6 +77,7 @@ private extension DiscoverSourceFiles {
                         root: rootPath
                     )
                 )
+                .map { String($0.dropFirst(2)) }
                 .map { append(root: rootPath, to: $0) }
                 .exclude(filesWithoutCoverageList(filesWithoutCoverage))
         )

--- a/Sources/muterCore/MuterRunSteps/DiscoverSourceFiles.swift
+++ b/Sources/muterCore/MuterRunSteps/DiscoverSourceFiles.swift
@@ -55,6 +55,7 @@ private extension DiscoverSourceFiles {
             "Spec",
             "Test",
             "fastlane",
+            "Package.swift"
         ]
     }
 

--- a/Tests/CLICommands/Steps/DiscoverSourceFilesTests.swift
+++ b/Tests/CLICommands/Steps/DiscoverSourceFilesTests.swift
@@ -1,4 +1,5 @@
 @testable import muterCore
+import TestingExtensions
 import XCTest
 
 final class DiscoverSourceFilesTests: MuterTestCase {
@@ -23,6 +24,7 @@ final class DiscoverSourceFilesTests: MuterTestCase {
                 "\(filsToDiscoverPath)/Directory1/file3.swift",
                 "\(filsToDiscoverPath)/Directory2/Directory3/file6.swift",
                 "\(filsToDiscoverPath)/ExampleApp/ExampleAppCode.swift",
+                "\(filsToDiscoverPath)/ExampleSpec.swift",
                 "\(filsToDiscoverPath)/file1.swift",
                 "\(filsToDiscoverPath)/file2.swift",
             ])
@@ -49,6 +51,7 @@ final class DiscoverSourceFilesTests: MuterTestCase {
             .sourceFileCandidatesDiscovered([
                 "\(filsToDiscoverPath)/Directory1/file3.swift",
                 "\(filsToDiscoverPath)/Directory2/Directory3/file6.swift",
+                "\(filsToDiscoverPath)/ExampleSpec.swift",
                 "\(filsToDiscoverPath)/file1.swift",
                 "\(filsToDiscoverPath)/file2.swift",
             ])
@@ -105,6 +108,7 @@ final class DiscoverSourceFilesTests: MuterTestCase {
         XCTAssertEqual(result, [
             .sourceFileCandidatesDiscovered([
                 "\(filsToDiscoverPath)/Directory1/file3.swift",
+                "\(filsToDiscoverPath)/ExampleSpec.swift",
                 "\(filsToDiscoverPath)/file1.swift",
                 "\(filsToDiscoverPath)/file2.swift",
             ])

--- a/Tests/fixtures/FilesToDiscover/Package.swift
+++ b/Tests/fixtures/FilesToDiscover/Package.swift
@@ -1,0 +1,10 @@
+//
+//  Package.swift
+//  muter
+//
+//  Created by Konstantinos Nikoloutsos on 13/12/23.
+//
+
+import Foundation
+
+// Immitating SPM Package.swift


### PR DESCRIPTION
Hello, this PR implements what is proposed here https://github.com/muter-mutation-testing/muter/issues/250 and  https://github.com/muter-mutation-testing/muter/issues/259

- Start excluding Package.swift by default
- Change the default exclusion paths to take `/` into consideration. Before `SpecialFeatureViewModel` was ignored because it cointained the substring "Spec". Now it is not ignored 🥳 . This feature gives the developer more flexibility