### PR TITLE
bug/env var on spm projects

### DIFF
--- a/Sources/muterCore/BuildSystems/ProcessFactory.swift
+++ b/Sources/muterCore/BuildSystems/ProcessFactory.swift
@@ -9,9 +9,9 @@ extension Process {
             let process = Process()
             process.qualityOfService = .userInitiated
 
-            process.environment = [
-                isMuterRunningKey: isMuterRunningValue
-            ]
+            var environment = ProcessInfo.processInfo.environment
+            environment[isMuterRunningKey] = isMuterRunningValue
+            process.environment = environment
 
             return process
         }

--- a/Sources/muterCore/BuildSystems/Xcode/XCTestRun.swift
+++ b/Sources/muterCore/BuildSystems/Xcode/XCTestRun.swift
@@ -37,7 +37,7 @@ struct XCTestRun: Equatable {
             }
 
             copy[testConfigurationsKey] = newTestConfigurations
-        } else { 
+        } else {
             // Legacy Tests configuration
             for (plistEntry, plistValue) in copy {
                 if let testConfiguration = plistValue as? [String: AnyHashable] {

--- a/Sources/muterCore/Extensions/SwiftSyntaxExtensions.swift
+++ b/Sources/muterCore/Extensions/SwiftSyntaxExtensions.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
 extension SyntaxProtocol {
-    var scapedDescription: String {
+    var escapedDescription: String {
         description.replacingOccurrences(
             of: "\n",
             with: "\\n"

--- a/Sources/muterCore/MutationOperators/MutationOperator.swift
+++ b/Sources/muterCore/MutationOperators/MutationOperator.swift
@@ -49,3 +49,15 @@ extension MutationOperator.Snapshot {
         )
     }
 }
+
+extension MutationOperator.Snapshot: CustomDebugStringConvertible {
+    var debugDescription: String {
+        """
+        MutationOperator.Snapshot(
+            before: "\(before)",
+            after: "\(after)",
+            description: "\(description)"
+        )
+        """
+    }
+}

--- a/Sources/muterCore/MutationOperators/SwapTernaryOperator.swift
+++ b/Sources/muterCore/MutationOperators/SwapTernaryOperator.swift
@@ -65,7 +65,6 @@ enum SwapTernaryOperator {
                     colon: node.colon,
                     elseExpression: node.thenExpression,
                     trailingTrivia: node.trailingTrivia
-
                 )
             )
         }
@@ -88,6 +87,8 @@ enum SwapTernaryOperator {
 
             children[index] = ExprSyntax(
                 UnresolvedTernaryExprSyntax(thenExpression: secondChoice)
+                    .withTrailingTrivia(.spaces(1))
+                    .withLeadingTrivia(.spaces(1))
             )
             children[index + 1] = firstChoice
 

--- a/Sources/muterCore/MutationSchemata/MutationPosition.swift
+++ b/Sources/muterCore/MutationSchemata/MutationPosition.swift
@@ -45,6 +45,18 @@ extension MutationPosition: CustomStringConvertible {
     }
 }
 
+extension MutationPosition: CustomDebugStringConvertible {
+    var debugDescription: String {
+        """
+        MutationPosition(
+            utf8Offset: \(utf8Offset),
+            line: \(line),
+            column: \(column)
+        )
+        """
+    }
+}
+
 extension MutationPosition: Nullable {
     static var null: MutationPosition {
         MutationPosition(utf8Offset: 0)

--- a/Sources/muterCore/MutationSchemata/MutationSchema.swift
+++ b/Sources/muterCore/MutationSchemata/MutationSchema.swift
@@ -53,10 +53,10 @@ extension MutationSchema: CustomStringConvertible, CustomDebugStringConvertible 
         Schemata(
             id: "\(id)",
             filePath: "\(filePath)",
-            mutationOperatorId: \(mutationOperatorId),
-            syntaxMutation: "\(syntaxMutation.scapedDescription)",
-            position: \(position),
-            snapshot: \(snapshot)
+            mutationOperatorId: .\(mutationOperatorId),
+            syntaxMutation: "\(syntaxMutation.escapedDescription)",
+            position: \(position.debugDescription),
+            snapshot: \(snapshot.debugDescription)
         )
         """
     }

--- a/Sources/muterCore/MutationSchemata/SchemataMutationMapping.swift
+++ b/Sources/muterCore/MutationSchemata/SchemataMutationMapping.swift
@@ -114,7 +114,7 @@ extension SchemataMutationMapping: CustomStringConvertible, CustomDebugStringCon
         let description = mappings.reduce(into: "") { accum, pair in
             accum +=
                 """
-                source: "\(pair.key.scapedDescription)",
+                source: "\(pair.key.escapedDescription)",
                 schemata: \(pair.value)
                 """
         }

--- a/Sources/muterCore/MutationSchemata/SchemataMutationMapping.swift
+++ b/Sources/muterCore/MutationSchemata/SchemataMutationMapping.swift
@@ -75,7 +75,7 @@ func + (
 
     let mergedMappgins = lhs.mappings.merging(rhs.mappings) { $0 + $1 }
 
-    mergedMappgins.forEach { codeBlock, schemata in
+    for (codeBlock, schemata) in mergedMappgins {
         result.add(codeBlock, schemata)
     }
 

--- a/Sources/muterCore/MuterRunSteps/BuildForTesting.swift
+++ b/Sources/muterCore/MuterRunSteps/BuildForTesting.swift
@@ -48,7 +48,8 @@ struct BuildForTesting: RunCommandStep {
         guard let buildDirectory = buildSettings
             .firstMatchOf("BUILD_DIR = (.+)")?
             .replacingOccurrences(of: "BUILD_DIR = ", with: "")
-            .trimmed else {
+            .trimmed
+        else {
             throw MuterError.literal(reason: "Could not extract `BUILD_DIR` from project settings")
         }
 

--- a/Sources/muterCore/MuterRunSteps/DiscoverSourceFiles.swift
+++ b/Sources/muterCore/MuterRunSteps/DiscoverSourceFiles.swift
@@ -68,7 +68,7 @@ private extension DiscoverSourceFiles {
         let excludeList = providedExcludeList + defaultExcludeList
         let subpaths = (fileManager.subpaths(atPath: rootPath) ?? [])
             .map { "./" + $0 }
-        
+
         return includeSwiftFiles(
             from: subpaths
                 .exclude(
@@ -94,7 +94,9 @@ private extension DiscoverSourceFiles {
         }
 
         return { path in
-            for item in excludeAlso where path.contains(item) { return true }
+            for item in excludeAlso where path.contains(item) {
+                return true
+            }
             return false
         }
     }

--- a/Sources/muterCore/Rewriters/AddImportRewriter.swift
+++ b/Sources/muterCore/Rewriters/AddImportRewriter.swift
@@ -49,6 +49,10 @@ final class AddImportRewriter: SyntaxRewriter {
 
 final class AddImportVisitior {
     func shouldAddImportStatement(_ node: SourceFileSyntax) -> Bool {
-        !node.description.contains("import Foundation")
+        let allImports = node
+            .description
+            .split(separator: "\n")
+            .filter { $0.contains("import ") }
+        return !allImports.any { $0.contains("Foundation") }
     }
 }

--- a/Sources/muterCore/Rewriters/MutationSwitch.swift
+++ b/Sources/muterCore/Rewriters/MutationSwitch.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SwiftSyntax
 
-struct MutationSwitch {
+enum MutationSwitch {
     static func apply(
         mutationSchemata: MutationSchemata,
         with originalSyntax: CodeBlockItemListSyntax

--- a/Tests/BuildSystems/XCTestRunTests.swift
+++ b/Tests/BuildSystems/XCTestRunTests.swift
@@ -30,7 +30,7 @@ final class XCTestRunTests: MuterTestCase {
         let testTargets = testConfiguration?["TestTargets"] as? [AnyHashable]
         let testTarget = testTargets?.first as? [String: AnyHashable]
         let environmentVariables = testTarget?["EnvironmentVariables"] as? [String: AnyHashable]
-        
+
         XCTAssertNotNil(environmentVariables?["keyToBeSet"])
         XCTAssertNotNil(environmentVariables?[isMuterRunningKey])
     }

--- a/Tests/MutationOperators/SwapTernaryOperatorTests.swift
+++ b/Tests/MutationOperators/SwapTernaryOperatorTests.swift
@@ -27,7 +27,7 @@ final class SwapTernaryOperatorTests: MuterTestCase {
                     .make(
                         filePath: sampleCode.path,
                         mutationOperatorId: .swapTernary,
-                        syntaxMutation: "\n    return a ? \"false\" : \"true\" ",
+                        syntaxMutation: "\n    return a  ? \"false\" :  \"true\" ",
                         position: MutationPosition(
                             utf8Offset: 199,
                             line: 10,
@@ -35,7 +35,7 @@ final class SwapTernaryOperatorTests: MuterTestCase {
                         ),
                         snapshot: MutationOperator.Snapshot(
                             before: "a ? \"true\" : \"false\"",
-                            after: "a ? \"false\" : \"true\"",
+                            after: "a  ? \"false\" :  \"true\"",
                             description: "swapped ternary operator"
                         )
                     )
@@ -47,7 +47,7 @@ final class SwapTernaryOperatorTests: MuterTestCase {
                     .make(
                         filePath: sampleCode.path,
                         mutationOperatorId: .swapTernary,
-                        syntaxMutation: "\n    return a ? false : true ",
+                        syntaxMutation: "\n    return a  ? false :  true ",
                         position: MutationPosition(
                             utf8Offset: 120,
                             line: 6,
@@ -55,7 +55,7 @@ final class SwapTernaryOperatorTests: MuterTestCase {
                         ),
                         snapshot: MutationOperator.Snapshot(
                             before: "a ? true : false",
-                            after: "a ? false : true",
+                            after: "a  ? false :  true",
                             description: "swapped ternary operator"
                         )
                     )
@@ -81,7 +81,7 @@ final class SwapTernaryOperatorTests: MuterTestCase {
                     .make(
                         filePath: sampleNestedCode.path,
                         mutationOperatorId: .swapTernary,
-                        syntaxMutation: "\n    return a ? false : b ? true : false ",
+                        syntaxMutation: "\n    return a  ? false :  b ? true : false ",
                         position: MutationPosition(
                             utf8Offset: 143,
                             line: 6,
@@ -89,14 +89,14 @@ final class SwapTernaryOperatorTests: MuterTestCase {
                         ),
                         snapshot: MutationOperator.Snapshot(
                             before: "a ? b ? true : false : false",
-                            after: "a ? false : b ? true : false",
+                            after: "a  ? false :  b ? true : false",
                             description: "swapped ternary operator"
                         )
                     ),
                     .make(
                         filePath: sampleNestedCode.path,
                         mutationOperatorId: .swapTernary,
-                        syntaxMutation: "\n    return a ? b ? false : true : false",
+                        syntaxMutation: "\n    return a ? b  ? false :  true : false",
                         position: MutationPosition(
                             utf8Offset: 136,
                             line: 6,
@@ -104,7 +104,7 @@ final class SwapTernaryOperatorTests: MuterTestCase {
                         ),
                         snapshot: MutationOperator.Snapshot(
                             before: "b ? true : false",
-                            after: "b ? false : true",
+                            after: "b  ? false :  true",
                             description: "swapped ternary operator"
                         )
                     )

--- a/Tests/MutationTesting/MutationTestingDelegateTests.swift
+++ b/Tests/MutationTesting/MutationTestingDelegateTests.swift
@@ -76,13 +76,8 @@ final class MutationTestingDelegateTests: MuterTestCase {
             and: FileHandle()
         )
 
-        XCTAssertEqual(
-            testProcess.environment,
-            [
-                "fileName_1_0_0": "YES",
-                isMuterRunningKey: isMuterRunningValue
-            ]
-        )
+        XCTAssertEqual(testProcess.environment?["fileName_1_0_0"], "YES")
+        XCTAssertEqual(testProcess.environment?[isMuterRunningKey], isMuterRunningValue)
         XCTAssertEqual(testProcess.arguments, ["test", "--skip-build"])
         XCTAssertEqual(testProcess.executableURL?.path, "/tmp/swift")
         XCTAssertEqual(testProcess.qualityOfService, .userInitiated)

--- a/Tests/TestDoubles/FileReportProvider.swift
+++ b/Tests/TestDoubles/FileReportProvider.swift
@@ -1,6 +1,6 @@
 @testable import muterCore
 
-class FileReportProvider {
+enum FileReportProvider {
 
     static var expectedFileReport1: MuterTestReport.FileReport {
         .init(fileName: "a module.swift", path: "/tmp/a module.swift", mutationScore: 100, appliedOperators: [

--- a/Tests/TestDoubles/Fixtures.swift
+++ b/Tests/TestDoubles/Fixtures.swift
@@ -196,7 +196,7 @@ extension SchemataMutationMapping {
         for (source, schemata) in mappings {
             let codeBlockSyntax = try sourceCode(source).statements
 
-            schemata.forEach { schema in
+            for schema in schemata {
                 schemataMutationMapping.add(codeBlockSyntax, schema)
             }
         }

--- a/muter.conf.yml
+++ b/muter.conf.yml
@@ -13,4 +13,5 @@ exclude:
 - RunCommandObserver.swift
 - ProgressExtensions.swift
 - BundleResource.swift
+- Operator.swift
 excludeCalls: []


### PR DESCRIPTION
When running projects for SPM, we are now copying the parent process environment variables to avoid weird issues and keep the process environment to be the same as were the user invokes their test command.

Fixes #267