### PR TITLE
[277] Missing "iPhone SE" simulator bug

### DIFF
--- a/AcceptanceTests/AcceptanceTests.swift
+++ b/AcceptanceTests/AcceptanceTests.swift
@@ -100,7 +100,7 @@ final class AcceptanceTests: XCTestCase {
         XCTAssertTrue(decodedConfiguration.testCommandArguments.contains("-destination"))
         XCTAssertTrue(
             decodedConfiguration.testCommandArguments
-                .contains("platform=iOS Simulator,name=iPhone SE (3rd generation)")
+                .contains { $0.contains("platform=iOS Simulator,name=iPhone") }
         )
     }
 

--- a/Sources/muterCore/Configuration/configurationGeneration.swift
+++ b/Sources/muterCore/Configuration/configurationGeneration.swift
@@ -153,7 +153,7 @@ private func iOSSimulator() -> Simulator {
             .compactMap { try JSONDecoder().decode(Simulator.self, from: $0) }
             .filter(\.isAvailable)
             .sorted(by: { $0.deviceTypeIdentifier > $1.deviceTypeIdentifier })
-            .first { $0.name.contains("iPhone SE") }
+            .first { $0.name.contains("iPhone") }
 
         return device ?? .fallback
     } catch {

--- a/Tests/Configuration/configurationGenerationTests.swift
+++ b/Tests/Configuration/configurationGenerationTests.swift
@@ -36,21 +36,23 @@ final class ConfigurationGenerationTests: MuterTestCase {
 
         let generatedConfiguration = MuterConfiguration(from: projectDirectoryContents)
 
-        XCTAssertEqual(
-            generatedConfiguration,
-            MuterConfiguration(
-                executable: "/path/to/xcodebuild",
-                arguments: [
-                    "-project",
-                    "iOSApp.xcodeproj",
-                    "-scheme",
-                    "iOSApp",
-                    "-destination",
-                    "platform=iOS Simulator,name=iPhone SE (3rd generation)",
-                    "test",
-                ]
-            )
+        let expectedConfiguration = MuterConfiguration(
+            executable: "/path/to/xcodebuild",
+            arguments: [
+                "-project",
+                "iOSApp.xcodeproj",
+                "-scheme",
+                "iOSApp",
+                "-destination",
+                "platform=iOS Simulator,name=iPhone SE (3rd generation)",
+                "test",
+            ]
         )
+
+        XCTAssertEqual(generatedConfiguration.testCommandExecutable, expectedConfiguration.testCommandExecutable)
+        XCTAssertEqual(generatedConfiguration.testCommandArguments.filter { !$0.contains("platform") },
+                       expectedConfiguration.testCommandArguments.filter { !$0.contains("platform") })
+        XCTAssertNotNil(generatedConfiguration.testCommandArguments.first { $0.contains("platform=iOS Simulator,name=iPhone") })
     }
 
     func test_iosProject() {
@@ -63,21 +65,23 @@ final class ConfigurationGenerationTests: MuterTestCase {
 
         let generatedConfiguration = MuterConfiguration(from: projectDirectoryContents)
 
-        XCTAssertEqual(
-            generatedConfiguration,
-            MuterConfiguration(
-                executable: "/path/to/xcodebuild",
-                arguments: [
-                    "-project",
-                    "iOSApp.xcodeproj",
-                    "-scheme",
-                    "iOSApp",
-                    "-destination",
-                    "platform=iOS Simulator,name=iPhone SE (3rd generation)",
-                    "test",
-                ]
-            )
+        let expectedConfiguration = MuterConfiguration(
+            executable: "/path/to/xcodebuild",
+            arguments: [
+                "-project",
+                "iOSApp.xcodeproj",
+                "-scheme",
+                "iOSApp",
+                "-destination",
+                "platform=iOS Simulator,name=iPhone SE (3rd generation)",
+                "test",
+            ]
         )
+
+        XCTAssertEqual(generatedConfiguration.testCommandExecutable, expectedConfiguration.testCommandExecutable)
+        XCTAssertEqual(generatedConfiguration.testCommandArguments.filter { !$0.contains("platform") },
+                       expectedConfiguration.testCommandArguments.filter { !$0.contains("platform") })
+        XCTAssertNotNil(generatedConfiguration.testCommandArguments.first { $0.contains("platform=iOS Simulator,name=iPhone") })
     }
 
     func test_xcodeWorkspace() {
@@ -92,21 +96,23 @@ final class ConfigurationGenerationTests: MuterTestCase {
 
         let generatedConfiguration = MuterConfiguration(from: projectDirectoryContents)
 
-        XCTAssertEqual(
-            generatedConfiguration,
-            MuterConfiguration(
-                executable: "/path/to/xcodebuild",
-                arguments: [
-                    "-project",
-                    "iOSApp.xcodeproj",
-                    "-scheme",
-                    "iOSApp",
-                    "-destination",
-                    "platform=iOS Simulator,name=iPhone SE (3rd generation)",
-                    "test",
-                ]
-            )
+        let expectedConfiguration = MuterConfiguration(
+            executable: "/path/to/xcodebuild",
+            arguments: [
+                "-project",
+                "iOSApp.xcodeproj",
+                "-scheme",
+                "iOSApp",
+                "-destination",
+                "platform=iOS Simulator,name=iPhone SE (3rd generation)",
+                "test",
+            ]
         )
+
+        XCTAssertEqual(generatedConfiguration.testCommandExecutable, expectedConfiguration.testCommandExecutable)
+        XCTAssertEqual(generatedConfiguration.testCommandArguments.filter { !$0.contains("platform") },
+                       expectedConfiguration.testCommandArguments.filter { !$0.contains("platform") })
+        XCTAssertNotNil(generatedConfiguration.testCommandArguments.first { $0.contains("platform=iOS Simulator,name=iPhone") })
     }
 
     func test_macOSProject() {
@@ -145,21 +151,23 @@ final class ConfigurationGenerationTests: MuterTestCase {
 
         let generatedConfiguration = MuterConfiguration(from: projectDirectoryContents)
 
-        XCTAssertEqual(
-            generatedConfiguration,
-            MuterConfiguration(
-                executable: "/path/to/xcodebuild",
-                arguments: [
-                    "-workspace",
-                    "iOSApp.xcworkspace",
-                    "-scheme",
-                    "iOSApp",
-                    "-destination",
-                    "platform=iOS Simulator,name=iPhone SE (3rd generation)",
-                    "test",
-                ]
-            )
+        let expectedConfiguration = MuterConfiguration(
+            executable: "/path/to/xcodebuild",
+            arguments: [
+                "-workspace",
+                "iOSApp.xcworkspace",
+                "-scheme",
+                "iOSApp",
+                "-destination",
+                "platform=iOS Simulator,name=iPhone SE (3rd generation)",
+                "test",
+            ]
         )
+
+        XCTAssertEqual(generatedConfiguration.testCommandExecutable, expectedConfiguration.testCommandExecutable)
+        XCTAssertEqual(generatedConfiguration.testCommandArguments.filter { !$0.contains("platform") },
+                       expectedConfiguration.testCommandArguments.filter { !$0.contains("platform") })
+        XCTAssertNotNil(generatedConfiguration.testCommandArguments.first { $0.contains("platform=iOS Simulator,name=iPhone") })
     }
 
     func test_macOSWorkspace() {


### PR DESCRIPTION
Currently, muter doesn't work if you don't have a simulator installed with a name that includes "iPhone SE". This MR allows for different iPhone simulators to be used, including refactoring test validation that checks lines that include the simulator.