### PR TITLE
Add mutation snapshot to JSON report

### DIFF
--- a/Sources/muterCore/Configuration/MuterConfiguration.swift
+++ b/Sources/muterCore/Configuration/MuterConfiguration.swift
@@ -122,9 +122,3 @@ extension MuterConfiguration {
         }
     }
 }
-
-private extension KeyedDecodingContainerProtocol {
-    func decode<A: Decodable>(_ type: A.Type, default: A, forKey key: KeyedDecodingContainer<Key>.Key) -> A {
-        (try? decode(A.self, forKey: key)) ?? `default`
-    }
-}

--- a/Sources/muterCore/Extensions/CodingExtensions.swift
+++ b/Sources/muterCore/Extensions/CodingExtensions.swift
@@ -1,0 +1,14 @@
+//
+//  CodingExtensions.swift
+//
+//
+//  Created by Annalise Mariottini on 4/12/24.
+//
+
+import Foundation
+
+extension KeyedDecodingContainerProtocol {
+    func decode<A: Decodable>(_ type: A.Type, default: A, forKey key: KeyedDecodingContainer<Key>.Key) -> A {
+        (try? decode(A.self, forKey: key)) ?? `default`
+    }
+}

--- a/Sources/muterCore/TestReporting/MuterTestReport.swift
+++ b/Sources/muterCore/TestReporting/MuterTestReport.swift
@@ -93,6 +93,7 @@ extension MuterTestReport {
         enum CodingKeys: String, CodingKey {
             case mutationPoint
             case testSuiteOutcome
+            case mutationSnapshot
         }
 
         init(
@@ -109,7 +110,7 @@ extension MuterTestReport {
             let container = try decoder.container(keyedBy: CodingKeys.self)
             mutationPoint = try container.decode(MutationPoint.self, forKey: .mutationPoint)
             testSuiteOutcome = try container.decode(TestSuiteOutcome.self, forKey: .testSuiteOutcome)
-            mutationSnapshot = .null
+            mutationSnapshot = container.decode(MutationOperator.Snapshot.self, default: .null, forKey: .mutationSnapshot)
         }
     }
 }

--- a/Tests/TestReporting/JsonReporterTests.swift
+++ b/Tests/TestReporting/JsonReporterTests.swift
@@ -16,5 +16,7 @@ final class JsonReporterTests: ReporterTestCase {
         // Basically, when we deserialize it, it's missing a field (`path`).
         XCTAssertEqual(actualReport.totalAppliedMutationOperators, 1)
         XCTAssertEqual(actualReport.fileReports.first?.fileName, "file3.swift")
+        XCTAssertEqual(actualReport.fileReports.first?.appliedOperators.map(\.mutationSnapshot),
+                       [.init(before: "!=", after: "==", description: "from != to ==")])
     }
 }


### PR DESCRIPTION
## Description

The mutation snapshot data is left out of the JSON report. I'd like to suggest that it be included, since it's very useful information, especially when consuming the output of the muter tool programmatically.

Let me know if you have any thoughts, suggestions, or objections.

Thanks!