### PR TITLE
[276] unlock xcodebuild with SPM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,7 @@ sourcekite
 muter.xcodeproj
 /Tests/bonmot_regression_test_output.json
 muterReport.json
-muter_logs
+muter_logs*
 AcceptanceTests/samples/*.*
 AcceptanceTests/Repositories/
 RegressionTests/samples/*.*
@@ -25,6 +25,7 @@ RegressionTests/parsercombinator_regression_test_output.json
 Repositories/UninitializedApp/muter.conf.json
 *_mutated
 .swiftpm
+temp
 
 
 ### macOS ###

--- a/Repositories/ExampleMacOSPackage/Package.swift
+++ b/Repositories/ExampleMacOSPackage/Package.swift
@@ -1,0 +1,23 @@
+// swift-tools-version: 5.9
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "ExampleMacOSPackage",
+    products: [
+        // Products define the executables and libraries a package produces, making them visible to other packages.
+        .library(
+            name: "ExampleMacOSPackage",
+            targets: ["ExampleMacOSPackage"]),
+    ],
+    targets: [
+        // Targets are the basic building blocks of a package, defining a module or a test suite.
+        // Targets can depend on other targets in this package and products from dependencies.
+        .target(
+            name: "ExampleMacOSPackage"),
+        .testTarget(
+            name: "ExampleMacOSPackageTests",
+            dependencies: ["ExampleMacOSPackage"]),
+    ]
+)

--- a/Repositories/ExampleMacOSPackage/Sources/ExampleMacOSPackage/App+Toggle.swift
+++ b/Repositories/ExampleMacOSPackage/Sources/ExampleMacOSPackage/App+Toggle.swift
@@ -1,0 +1,7 @@
+extension App {
+    static func toggle() {
+        globalToggle.toggle()
+    }
+}
+
+private var globalToggle: Bool = false

--- a/Repositories/ExampleMacOSPackage/Sources/ExampleMacOSPackage/App.swift
+++ b/Repositories/ExampleMacOSPackage/Sources/ExampleMacOSPackage/App.swift
@@ -1,0 +1,6 @@
+@main
+struct App {
+    static func main() {
+        toggle()
+    }
+}

--- a/Repositories/ExampleMacOSPackage/Sources/ExampleMacOSPackage/Module.swift
+++ b/Repositories/ExampleMacOSPackage/Sources/ExampleMacOSPackage/Module.swift
@@ -1,0 +1,3 @@
+func areEqual(_ a: Int, and b: Int) -> Bool {
+    a == b
+}

--- a/Repositories/ExampleMacOSPackage/Sources/ExampleMacOSPackage/Module2.swift
+++ b/Repositories/ExampleMacOSPackage/Sources/ExampleMacOSPackage/Module2.swift
@@ -1,0 +1,3 @@
+func shouldReturnTrue() -> Bool {
+    return true && false
+}

--- a/Repositories/ExampleMacOSPackage/Tests/ExampleMacOSPackageTests/ExampleMacOSPackageTests.swift
+++ b/Repositories/ExampleMacOSPackage/Tests/ExampleMacOSPackageTests/ExampleMacOSPackageTests.swift
@@ -1,0 +1,9 @@
+import XCTest
+@testable import ExampleMacOSPackage
+
+final class ExampleMacOSPackageTests: XCTestCase {
+    func test() {
+        XCTAssert(areEqual(5, and: 5))
+        XCTAssertFalse(areEqual(5, and: 6))
+    }
+}

--- a/Repositories/ExampleiOSPackage/Package.swift
+++ b/Repositories/ExampleiOSPackage/Package.swift
@@ -1,0 +1,26 @@
+// swift-tools-version: 5.9
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "ExampleiOSPackage",
+    platforms: [
+        .iOS(.v14)
+    ],
+    products: [
+        // Products define the executables and libraries a package produces, making them visible to other packages.
+        .library(
+            name: "ExampleiOSPackage",
+            targets: ["ExampleiOSPackage"]),
+    ],
+    targets: [
+        // Targets are the basic building blocks of a package, defining a module or a test suite.
+        // Targets can depend on other targets in this package and products from dependencies.
+        .target(
+            name: "ExampleiOSPackage"),
+        .testTarget(
+            name: "ExampleiOSPackageTests",
+            dependencies: ["ExampleiOSPackage"]),
+    ]
+)

--- a/Repositories/ExampleiOSPackage/Sources/ExampleiOSPackage/AppDelegate.swift
+++ b/Repositories/ExampleiOSPackage/Sources/ExampleiOSPackage/AppDelegate.swift
@@ -1,0 +1,11 @@
+import UIKit
+
+@UIApplicationMain
+class AppDelegate: UIResponder, UIApplicationDelegate {
+
+    var window: UIWindow?
+
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+        return true
+    }
+}

--- a/Repositories/ExampleiOSPackage/Sources/ExampleiOSPackage/Module.swift
+++ b/Repositories/ExampleiOSPackage/Sources/ExampleiOSPackage/Module.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+func areEqual(_ a: Int, and b: Int) -> Bool {
+    a == b
+}

--- a/Repositories/ExampleiOSPackage/Sources/ExampleiOSPackage/Module2.swift
+++ b/Repositories/ExampleiOSPackage/Sources/ExampleiOSPackage/Module2.swift
@@ -1,0 +1,3 @@
+func shouldReturnTrue() -> Bool {
+    return true && false
+}

--- a/Repositories/ExampleiOSPackage/Sources/ExampleiOSPackage/ViewController.swift
+++ b/Repositories/ExampleiOSPackage/Sources/ExampleiOSPackage/ViewController.swift
@@ -1,0 +1,7 @@
+import UIKit
+
+class ViewController: UIViewController {
+    override func viewDidLoad() {
+        super.viewDidLoad()
+    }
+}

--- a/Repositories/ExampleiOSPackage/Tests/ExampleiOSPackageTests/ExampleiOSPackageTests.swift
+++ b/Repositories/ExampleiOSPackage/Tests/ExampleiOSPackageTests/ExampleiOSPackageTests.swift
@@ -1,0 +1,9 @@
+import XCTest
+@testable import ExampleiOSPackage
+
+final class ExampleiOSPackageTests: XCTestCase {
+    func test() {
+        XCTAssert(areEqual(5, and: 5))
+        XCTAssertFalse(areEqual(5, and: 6))
+    }
+}

--- a/Sources/muterCore/BuildSystems/Xcode/XcodeBuildCoverage.swift
+++ b/Sources/muterCore/BuildSystems/Xcode/XcodeBuildCoverage.swift
@@ -32,14 +32,7 @@ final class XcodeBuildCoverage: BuildSystemCoverage {
     }
 
     func buildDirectory(_ configuration: MuterConfiguration) -> String? {
-        process().runProcess(
-            url: configuration.testCommandExecutable,
-            arguments: configuration.testCommandArguments + ["-showBuildSettings"]
-        )
-        .flatMap { $0.firstMatchOf("BUILD_DIR = (.+)", options: .anchorsMatchLines) }
-        .map(\.trimmed)
-        .flatMap(\.nilIfEmpty)
-        .flatMap { URL(fileURLWithPath: $0).deletingLastPathComponent().path }
+        "\(configuration.buildPath)/Build"
     }
 
     private func runTestsWithCoverageEnabled(

--- a/Sources/muterCore/MutationSteps/CopyProjectToTempDirectory.swift
+++ b/Sources/muterCore/MutationSteps/CopyProjectToTempDirectory.swift
@@ -20,6 +20,17 @@ class CopyProjectToTempDirectory: MutationStep {
                 toPath: state.mutatedProjectDirectoryURL.path
             )
 
+            let copiedBuildDirectory: String
+            if #available(macOS 13.0, *) {
+                copiedBuildDirectory = state.mutatedProjectDirectoryURL.appending(path: state.muterConfiguration.buildPath).path
+            } else {
+                copiedBuildDirectory = state.mutatedProjectDirectoryURL.appendingPathComponent(state.muterConfiguration.buildPath).path
+            }
+            // ensure that we don't have any dirty build state before running tests in copied directory
+            if fileManager.fileExists(atPath: copiedBuildDirectory) {
+                try fileManager.removeItem(atPath: copiedBuildDirectory)
+            }
+
             notificationCenter.post(
                 name: .projectCopyFinished,
                 object: state.mutatedProjectDirectoryURL.path

--- a/Tests/BuildSystems/SwiftCoverageTests.swift
+++ b/Tests/BuildSystems/SwiftCoverageTests.swift
@@ -22,6 +22,8 @@ final class SwiftCoverageTests: MuterTestCase {
 
         XCTAssertEqual(
             process.arguments, [
+                "--build-path",
+                ".build",
                 "--enable-code-coverage",
             ]
         )

--- a/Tests/BuildSystems/XcodeBuildCoverageTests.swift
+++ b/Tests/BuildSystems/XcodeBuildCoverageTests.swift
@@ -16,7 +16,7 @@ final class XcodeBuildCoverageTests: MuterTestCase {
         _ = sut.run(with: muterConfiguration)
 
         XCTAssertEqual(process.executableURL?.path, "/path/to/xcodebuild")
-        XCTAssertEqual(process.arguments, ["-enableCodeCoverage", "YES"])
+        XCTAssertEqual(process.arguments, ["-derivedDataPath", ".build", "-enableCodeCoverage", "YES"])
     }
 
     func test_whenRunWithCoverageSucceeds_thenRunXcovCommand() {
@@ -91,7 +91,6 @@ final class XcodeBuildCoverageTests: MuterTestCase {
     }
 
     func test_functionCoverage() throws {
-        process.stdoutToBeReturned = "BUILD_DIR = /build/directory"
         process.stdoutToBeReturned = "/path/to/testExecutable.xctest"
         process.stdoutToBeReturned = "/path/to/testBinary"
         process.stdoutToBeReturned = "/path/to/coverage.profdata"

--- a/Tests/Configuration/configurationGenerationTests.swift
+++ b/Tests/Configuration/configurationGenerationTests.swift
@@ -2,7 +2,7 @@
 import XCTest
 
 final class ConfigurationGenerationTests: MuterTestCase {
-    func test_swiftPackageManagerProject() {
+    func test_swiftPackageManagerProject_withNoSpecifiedPlatform() {
         let projectDirectoryContents = [
             "/some/path/Package.swift",
             "/some/path/Package@swift-5.11.swift",
@@ -11,6 +11,12 @@ final class ConfigurationGenerationTests: MuterTestCase {
         ]
 
         process.stdoutToBeReturned = "/path/to/swift"
+        process.stdoutToBeReturned = """
+        {
+            "name": "SPMLibrary",
+            "platforms": []
+        }
+        """
 
         let generatedConfiguration = MuterConfiguration(from: projectDirectoryContents)
 
@@ -25,6 +31,136 @@ final class ConfigurationGenerationTests: MuterTestCase {
     }
 
     #if !os(Linux)
+    func test_swiftPackageManagerProject_withMacOSPlatform() {
+        let projectDirectoryContents = [
+            "/some/path/Package.swift",
+            "/some/path/Package@swift-5.11.swift",
+            "/some/path/main.swift",
+            "/some/path/PackageIgnoreMe.swift",
+        ]
+
+        process.stdoutToBeReturned = "/path/to/swift"
+        process.stdoutToBeReturned = """
+        {
+            "name": "SPMLibrary",
+            "platforms": [
+                {
+                    "platformName": "macos"
+                }
+            ]
+        }
+        """
+
+        let generatedConfiguration = MuterConfiguration(from: projectDirectoryContents)
+
+        XCTAssertEqual(
+            generatedConfiguration,
+            MuterConfiguration(
+                executable: "/path/to/swift",
+                arguments: ["test"],
+                excludeList: ["Package.swift", "Package@swift-5.11.swift"]
+            )
+        )
+    }
+
+    func test_swiftPackageManagerProject_withiOSPlatform() {
+        let projectDirectoryContents = [
+            "/some/path/Package.swift",
+            "/some/path/Package@swift-5.11.swift",
+            "/some/path/main.swift",
+            "/some/path/PackageIgnoreMe.swift",
+        ]
+
+        process.stdoutToBeReturned = "/path/to/swift"
+        process.stdoutToBeReturned = """
+        {
+            "name": "SPMLibrary",
+            "platforms": [
+                {
+                    "platformName": "ios"
+                }
+            ]
+        }
+        """
+        process.stdoutToBeReturned = "/path/to/xcodebuild"
+        process.stdoutToBeReturned = """
+        {
+            "workspace": {
+                "schemes": [
+                    "SPMLibrary"
+                ]
+            }
+        }
+        """
+
+        let generatedConfiguration = MuterConfiguration(from: projectDirectoryContents)
+
+        XCTAssertEqual(
+            generatedConfiguration,
+            MuterConfiguration(
+                executable: "/path/to/xcodebuild",
+                arguments: [
+                    "-scheme",
+                    "SPMLibrary",
+                    "-destination",
+                    "platform=iOS Simulator,name=iPhone SE (3rd generation)",
+                    "test",
+                ],
+                excludeList: ["Package.swift", "Package@swift-5.11.swift"]
+            )
+        )
+    }
+
+    func test_swiftPackageManagerProject_withiOSPlatform_andMultipleSchemes() {
+        let projectDirectoryContents = [
+            "/some/path/Package.swift",
+            "/some/path/Package@swift-5.11.swift",
+            "/some/path/main.swift",
+            "/some/path/PackageIgnoreMe.swift",
+        ]
+
+        process.stdoutToBeReturned = "/path/to/swift"
+        process.stdoutToBeReturned = """
+        {
+            "name": "SPMLibrary",
+            "platforms": [
+                {
+                    "platformName": "ios"
+                }
+            ]
+        }
+        """
+        process.stdoutToBeReturned = "/path/to/xcodebuild"
+        process.stdoutToBeReturned = """
+        {
+            "workspace": {
+                "schemes": [
+                    "SPMLibrary",
+                    "SPMLibraryInternal",
+                    "SPMLibrary-Package",
+                ]
+            }
+        }
+        """
+
+        let generatedConfiguration = MuterConfiguration(from: projectDirectoryContents)
+
+        XCTAssertEqual(
+            generatedConfiguration,
+            MuterConfiguration(
+                executable: "/path/to/xcodebuild",
+                arguments: [
+                    "-scheme",
+                    "SPMLibrary-Package",
+                    "-destination",
+                    "platform=iOS Simulator,name=iPhone SE (3rd generation)",
+                    "test",
+                ],
+                excludeList: ["Package.swift", "Package@swift-5.11.swift"]
+            )
+        )
+    }
+
     func test_xcodeProject() {
         let projectDirectoryContents = [
             "/some/path/Package.swift",
@@ -36,27 +172,20 @@ final class ConfigurationGenerationTests: MuterTestCase {
 
         let generatedConfiguration = MuterConfiguration(from: projectDirectoryContents)
 
-        let expectedConfiguration = MuterConfiguration(
-            executable: "/path/to/xcodebuild",
-            arguments: [
-                "-project",
-                "iOSApp.xcodeproj",
-                "-scheme",
-                "iOSApp",
-                "-destination",
-                "platform=iOS Simulator,name=iPhone SE (3rd generation)",
-                "test",
-            ]
-        )
-
-        XCTAssertEqual(generatedConfiguration.testCommandExecutable, expectedConfiguration.testCommandExecutable)
         XCTAssertEqual(
-            generatedConfiguration.testCommandArguments.filter { !$0.contains("platform") },
-            expectedConfiguration.testCommandArguments.filter { !$0.contains("platform") }
-        )
-        XCTAssertNotNil(
-            generatedConfiguration.testCommandArguments
-                .first { $0.contains("platform=iOS Simulator,name=iPhone") }
+            generatedConfiguration,
+            MuterConfiguration(
+                executable: "/path/to/xcodebuild",
+                arguments: [
+                    "-project",
+                    "iOSApp.xcodeproj",
+                    "-scheme",
+                    "iOSApp",
+                    "-destination",
+                    "platform=iOS Simulator,name=iPhone SE (3rd generation)",
+                    "test",
+                ]
+            )
         )
     }
 
@@ -70,27 +199,20 @@ final class ConfigurationGenerationTests: MuterTestCase {
 
         let generatedConfiguration = MuterConfiguration(from: projectDirectoryContents)
 
-        let expectedConfiguration = MuterConfiguration(
-            executable: "/path/to/xcodebuild",
-            arguments: [
-                "-project",
-                "iOSApp.xcodeproj",
-                "-scheme",
-                "iOSApp",
-                "-destination",
-                "platform=iOS Simulator,name=iPhone SE (3rd generation)",
-                "test",
-            ]
-        )
-
-        XCTAssertEqual(generatedConfiguration.testCommandExecutable, expectedConfiguration.testCommandExecutable)
         XCTAssertEqual(
-            generatedConfiguration.testCommandArguments.filter { !$0.contains("platform") },
-            expectedConfiguration.testCommandArguments.filter { !$0.contains("platform") }
-        )
-        XCTAssertNotNil(
-            generatedConfiguration.testCommandArguments
-                .first { $0.contains("platform=iOS Simulator,name=iPhone") }
+            generatedConfiguration,
+            MuterConfiguration(
+                executable: "/path/to/xcodebuild",
+                arguments: [
+                    "-project",
+                    "iOSApp.xcodeproj",
+                    "-scheme",
+                    "iOSApp",
+                    "-destination",
+                    "platform=iOS Simulator,name=iPhone SE (3rd generation)",
+                    "test",
+                ]
+            )
         )
     }
 
@@ -106,27 +228,20 @@ final class ConfigurationGenerationTests: MuterTestCase {
 
         let generatedConfiguration = MuterConfiguration(from: projectDirectoryContents)
 
-        let expectedConfiguration = MuterConfiguration(
-            executable: "/path/to/xcodebuild",
-            arguments: [
-                "-project",
-                "iOSApp.xcodeproj",
-                "-scheme",
-                "iOSApp",
-                "-destination",
-                "platform=iOS Simulator,name=iPhone SE (3rd generation)",
-                "test",
-            ]
-        )
-
-        XCTAssertEqual(generatedConfiguration.testCommandExecutable, expectedConfiguration.testCommandExecutable)
         XCTAssertEqual(
-            generatedConfiguration.testCommandArguments.filter { !$0.contains("platform") },
-            expectedConfiguration.testCommandArguments.filter { !$0.contains("platform") }
-        )
-        XCTAssertNotNil(
-            generatedConfiguration.testCommandArguments
-                .first { $0.contains("platform=iOS Simulator,name=iPhone") }
+            generatedConfiguration,
+            MuterConfiguration(
+                executable: "/path/to/xcodebuild",
+                arguments: [
+                    "-project",
+                    "iOSApp.xcodeproj",
+                    "-scheme",
+                    "iOSApp",
+                    "-destination",
+                    "platform=iOS Simulator,name=iPhone SE (3rd generation)",
+                    "test",
+                ]
+            )
         )
     }
 
@@ -166,27 +281,20 @@ final class ConfigurationGenerationTests: MuterTestCase {
 
         let generatedConfiguration = MuterConfiguration(from: projectDirectoryContents)
 
-        let expectedConfiguration = MuterConfiguration(
-            executable: "/path/to/xcodebuild",
-            arguments: [
-                "-workspace",
-                "iOSApp.xcworkspace",
-                "-scheme",
-                "iOSApp",
-                "-destination",
-                "platform=iOS Simulator,name=iPhone SE (3rd generation)",
-                "test",
-            ]
-        )
-
-        XCTAssertEqual(generatedConfiguration.testCommandExecutable, expectedConfiguration.testCommandExecutable)
         XCTAssertEqual(
-            generatedConfiguration.testCommandArguments.filter { !$0.contains("platform") },
-            expectedConfiguration.testCommandArguments.filter { !$0.contains("platform") }
-        )
-        XCTAssertNotNil(
-            generatedConfiguration.testCommandArguments
-                .first { $0.contains("platform=iOS Simulator,name=iPhone") }
+            generatedConfiguration,
+            MuterConfiguration(
+                executable: "/path/to/xcodebuild",
+                arguments: [
+                    "-workspace",
+                    "iOSApp.xcworkspace",
+                    "-scheme",
+                    "iOSApp",
+                    "-destination",
+                    "platform=iOS Simulator,name=iPhone SE (3rd generation)",
+                    "test",
+                ]
+            )
         )
     }
 

--- a/Tests/MutationSteps/BuildForTestingTests.swift
+++ b/Tests/MutationSteps/BuildForTestingTests.swift
@@ -59,21 +59,7 @@ final class BuildForTestingTests: MuterTestCase {
         )
     }
 
-    func test_runShowBuildSettings() async throws {
-        state.muterConfiguration = MuterConfiguration(
-            executable: "/path/to/xcodebuild",
-            arguments: ["some", "commands", "test"]
-        )
-
-        process.stdoutToBeReturned = ""
-
-        _ = try? await sut.run(with: state)
-
-        XCTAssertEqual(process.executableURL?.path, "/path/to/xcodebuild")
-        XCTAssertEqual(process.arguments, ["-showBuildSettings"])
-    }
-
-    func test_whenCannotParseBuildDirectoryThenThrowError() async throws {
+    func test_runBuildForTestingCommandFails() async throws {
         state.muterConfiguration = MuterConfiguration(
             executable: "/path/to/xcodebuild",
             arguments: ["some", "commands", "test"]
@@ -83,7 +69,7 @@ final class BuildForTestingTests: MuterTestCase {
 
         try await assertThrowsMuterError(
             await sut.run(with: state),
-            .literal(reason: "Could not find `BUILD_DIR`")
+            .literal(reason: "Could not run test with -build-for-testing argument")
         )
     }
 
@@ -94,7 +80,6 @@ final class BuildForTestingTests: MuterTestCase {
         )
 
         state.mutatedProjectDirectoryURL = URL(fileURLWithPath: "/path/to/temp")
-        process.stdoutToBeReturned = xcodebuildShowBuildSettingsOutput()
         process.stdoutToBeReturned = xcodebuildBuildForTestingOutput()
         fileManager.errorToThrow = TestingError.stub
 
@@ -111,7 +96,6 @@ final class BuildForTestingTests: MuterTestCase {
         )
 
         state.mutatedProjectDirectoryURL = URL(fileURLWithPath: "/path/to/temp")
-        process.stdoutToBeReturned = xcodebuildShowBuildSettingsOutput()
         process.stdoutToBeReturned = xcodebuildBuildForTestingOutput()
         fileManager.contentsAtPathSortedToReturn = [""]
 
@@ -128,7 +112,6 @@ final class BuildForTestingTests: MuterTestCase {
         )
 
         state.mutatedProjectDirectoryURL = URL(fileURLWithPath: "/path/to/temp")
-        process.stdoutToBeReturned = xcodebuildShowBuildSettingsOutput()
         process.stdoutToBeReturned = xcodebuildBuildForTestingOutput()
         fileManager.contentsAtPathSortedToReturn = ["some/project.xctestrun"]
 
@@ -156,30 +139,6 @@ final class BuildForTestingTests: MuterTestCase {
 
 
         ** TEST BUILD SUCCEEDED **
-        """
-    }
-
-    private func xcodebuildShowBuildSettingsOutput() -> String {
-        """
-        AUTOMATICALLY_MERGE_DEPENDENCIES = NO
-            AVAILABLE_PLATFORMS = appletvos appletvsimulator driverkit iphoneos iphonesimulator macosx watchos watchsimulator
-            BITCODE_GENERATION_MODE = marker
-            BUILD_ACTIVE_RESOURCES_ONLY = NO
-            BUILD_COMPONENTS = headers build
-            BUILD_DIR = /user/Library/Developer/Xcode/DerivedData/App-gkbxrvayhpqhtperezjiwgahsiuy/Build/Products
-            BUILD_LIBRARY_FOR_DISTRIBUTION = NO
-            BUILD_ROOT = /user/Library/Developer/Xcode/DerivedData/App-gkbxrvayhpqhtperezjiwgahsiuy/Build/Products
-            BUILD_STYLE =
-            BUILD_VARIANTS = normal
-            BUILT_PRODUCTS_DIR = /user/Library/Developer/Xcode/DerivedData/App-gkbxrvayhpqhtperezjiwgahsiuy/Build/Products/Release-iphoneos
-            BUNDLE_CONTENTS_FOLDER_PATH_deep = Contents/
-            BUNDLE_EXECUTABLE_FOLDER_NAME_deep = MacOS
-            BUNDLE_EXTENSIONS_FOLDER_PATH = Extensions
-            BUNDLE_FORMAT = shallow
-            BUNDLE_FRAMEWORKS_FOLDER_PATH = Frameworks
-            BUNDLE_PLUGINS_FOLDER_PATH = PlugIns
-            BUNDLE_PRIVATE_HEADERS_FOLDER_PATH = PrivateHeaders
-            BUNDLE_PUBLIC_HEADERS_FOLDER_PATH = Headers
         """
     }
 

--- a/Tests/MutationSteps/CopyProjectToTempDirectoryTests.swift
+++ b/Tests/MutationSteps/CopyProjectToTempDirectoryTests.swift
@@ -19,7 +19,7 @@ final class CopyProjectToTempDirectoryTests: MuterTestCase {
         XCTAssertEqual(fileManager.copyPaths.first?.source, "/some/projectName")
         XCTAssertEqual(fileManager.copyPaths.first?.dest, "/tmp/projectName")
         XCTAssertEqual(fileManager.copyPaths.count, 1)
-        XCTAssertEqual(fileManager.methodCalls, ["copyItem(atPath:toPath:)"])
+        XCTAssertEqual(fileManager.methodCalls, ["copyItem(atPath:toPath:)", "fileExists(atPath:)"])
     }
 
     func test_whenItsUnableToCopyAProjectIntoATempDirectory() async throws {

--- a/Tests/MutationTesting/MutationTestingDelegateTests.swift
+++ b/Tests/MutationTesting/MutationTestingDelegateTests.swift
@@ -51,6 +51,8 @@ final class MutationTestingDelegateTests: MuterTestCase {
             "platform=macOS,arch=x86_64,variant=Mac Catalyst",
             "-xctestrun",
             "muter.xctestrun",
+            "-derivedDataPath",
+            ".build",
         ])
 
         XCTAssertEqual(testProcess.executableURL?.path, "/tmp/xcodebuild")
@@ -77,7 +79,7 @@ final class MutationTestingDelegateTests: MuterTestCase {
 
         XCTAssertEqual(testProcess.environment?[schemata.id], "YES")
         XCTAssertEqual(testProcess.environment?[isMuterRunningKey], isMuterRunningValue)
-        XCTAssertEqual(testProcess.arguments, ["test", "--skip-build"])
+        XCTAssertEqual(testProcess.arguments, ["test", "--skip-build", "--build-path", ".build"])
         XCTAssertEqual(testProcess.executableURL?.path, "/tmp/swift")
     }
 


### PR DESCRIPTION
## Description

As muter stands today, SPM projects cannot use `xcodebuild` as a test executable. This is unfortunate, since any SPM projects that targets iOS, watchOS, tvOS, or visionOS must rely on `xcodebuild` to run tests with an available simulator.

### Build Path Changes

The biggest blocker for using `xcodebuild` in muter's current state is the use of `-showBuildSettings` to get the build path. This is because `-showBuildSettings` does not work the same for SPM projects as it does for Xcode projects. It requires a scheme to be passed, and it also does not output the `BUILD_DIR` line needed to get the build path.

As a solution to the build path issue, I've decided to utilize the ability to pass an explicit build path to `xcodebuild`  with the flag `-derivedDataPath`. To keep parity, I'm also using `--build-path` with the `swift` executable. To allow consumers to specify a custom build path, I've added `buildPath` as a value in the muter config, defaulting to `.build`.

With this change, we can now run muter on an SPM project with `xcodebuild` without issue. 🎉 

### SPM Muter Config Init

Since `xcodebuild` is now available for SPM, I've added configuration generation logic that detects if an SPM project is targeting iOS. If iOS is detected as a platform, then the `xcodebuild` executable is added, along with the flags necessary to run the correct scheme and simulator.

Since muter only currently supports iOS simulators, I have not added anything related to the other simulators that might be available.

### Acceptance Test Additions

I've added two new example repositories for acceptance tests:
- ExampleiOSPackage
- ExampleMacOSPackage

The test script runs the same acceptance test on ExampleiOSPackage as is currently run on ExampleApp. It also runs the same acceptance test on ExampleMacOSPackage as is currently run on ExampleMacOSApp.

To be able to differentiate between the output for app vs. package, I've added the suffix `spm` and `xcodeproj` to the test output files. This is utilized in the `AcceptanceTests` suite to verify the output of running the acceptance tests.

I also changed the acceptance tests to run in a `temp` directory, which to me seems cleaner than running in the `AcceptanceTests` directory. However, I'm open to undoing this change if the project maintainers prefer the old way, as it's not necessary for this MR.