### PR TITLE
Fix install command to work without sudo

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,7 +59,7 @@ Both of these test suites are lengthy (~5 minutes). Budget your time accordingly
 It's possible (and encouraged!) to run Muter on itself. To do this with the version of the code you've been working on, run:
 
 ```
-make install
+make install prefix=$(brew --prefix)
 make mutation-test
 ```
 

--- a/README.md
+++ b/README.md
@@ -110,14 +110,14 @@ You can build Muter from source, and get the latest set of features/improvements
 ```sh
 git clone https://github.com/muter-mutation-testing/muter.git
 cd muter
-make install
+make install prefix=$(brew --prefix)
 ```
 
 If you've already installed Muter via homebrew, this will install over it. If you've done this, and want to go back to the latest version you've downloaded through homebrew, run the following:
 
 ```sh
-make uninstall
-brew link muter
+make uninstall prefix=$(brew --prefix)
+brew unlink muter && brew link muter
 ```
 
 ## Development


### PR DESCRIPTION
Update README.md and CONTRIBUTING.md to use `make install prefix=$(brew --prefix)` instead of plain `make install`.

The default prefix (/usr/local) requires sudo on most systems, while using homebrew's prefix avoids this issue. This matches how the homebrew formula installs muter.

Also fixes the uninstall instructions to properly relink homebrew's version.