### PR TITLE
Fix nested code block mutations producing false survivors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -145,3 +145,12 @@ iOSInjectionProject/
 **/xcshareddata/WorkspaceSettings.xcsettings
 
 # End of https://www.gitignore.io/api/swift,xcode,macos
+
+# Muter artifacts
+logFileName
+muter_logs/
+muter_tmp/
+
+# Snapshot backup/conflict files
+*.txt.bak
+*\ 2.txt

--- a/Sources/muterCore/Rewriters/MuterRewriter.swift
+++ b/Sources/muterCore/Rewriters/MuterRewriter.swift
@@ -8,15 +8,19 @@ final class MuterRewriter: SyntaxRewriter {
     }
 
     override func visit(_ node: CodeBlockItemListSyntax) -> CodeBlockItemListSyntax {
+        // Visit children FIRST (bottom-up) so inner code blocks get their
+        // mutation switches while their SyntaxIdentifiers still match the
+        // dictionary keys. Applying the outer switch first (top-down) creates
+        // a new syntax tree that changes all inner node IDs, breaking lookups.
+        let visitedNode = super.visit(node)
+
         guard let mutationSchemata = schemataMappings.schemata(node) else {
-            return super.visit(node)
+            return visitedNode
         }
 
-        let newNode = MutationSwitch.apply(
+        return MutationSwitch.apply(
             mutationSchemata: mutationSchemata,
-            with: node
+            with: visitedNode
         )
-
-        return super.visit(newNode)
     }
 }

--- a/Tests/MutationOperators/RemoveSideEffectsOperatorTests.swift
+++ b/Tests/MutationOperators/RemoveSideEffectsOperatorTests.swift
@@ -102,4 +102,76 @@ final class RemoveSideEffectsOperatorTests: MuterTestCase {
 
         AssertSnapshot(formatCode(rewriter.description))
     }
+
+    // MARK: - Nested code block regression (muter#283)
+
+    /// Proves that the schemata rewriter emits mutation switches at BOTH nesting
+    /// levels when nested for loops each contain RemoveSideEffects targets.
+    ///
+    /// The bug: `SchemataMutationMapping` keys `CodeBlockItemListSyntax` nodes
+    /// by `SyntaxIdentifier` (pointer + tree index). When `MuterRewriter`
+    /// replaces an outer code block with a mutation switch, all inner nodes get
+    /// new identities. The dictionary lookup for the inner code block then fails,
+    /// silently dropping the inner mutation. At runtime the inner mutation's env
+    /// var has no corresponding if-branch, so the original code always runs, tests
+    /// pass, and muter reports a false "survived".
+    func test_nestedForLoopsProduceMutationSwitchesAtBothLevels() throws {
+        let source = try sourceCode(
+            """
+            func process(groups: [[String]]) {
+                for group in groups {
+                    sideEffect("outer")
+                    for item in group {
+                        sideEffect("inner")
+                    }
+                }
+            }
+            """
+        )
+
+        let sourceInfo = SourceCodeInfo(path: "/path/to/file", code: source)
+        let visitor = RemoveSideEffectsOperator.Visitor(
+            sourceCodeInfo: sourceInfo
+        )
+
+        visitor.walk(source)
+
+        let mappings = visitor.schemataMappings
+
+        // The visitor must find two mutations:
+        // 1. Removing sideEffect("outer") from the outer for body
+        // 2. Removing sideEffect("inner") from the inner for body
+        XCTAssertEqual(
+            mappings.mutationSchemata.count, 2,
+            "Visitor should register mutations at both nesting levels"
+        )
+
+        // Now rewrite and verify both mutation switches appear
+        let rewritten = MuterRewriter(mappings).rewrite(source).description
+
+        let mutationSwitchCount = rewritten
+            .components(separatedBy: "ProcessInfo.processInfo.environment[")
+            .count - 1
+
+        // There are 2 schemata so there must be 2 env-var checks in the
+        // rewritten source — one for the outer mutation, one for the inner.
+        XCTAssertEqual(
+            mutationSwitchCount, 2,
+            "Rewritten source must contain mutation switches at both nesting "
+            + "levels. Found \(mutationSwitchCount) instead of 2. "
+            + "This indicates the inner mutation switch was silently dropped "
+            + "because the CodeBlockItemListSyntax identity changed when the "
+            + "outer code block was rewritten."
+        )
+
+        // Additionally verify each specific schemata ID appears
+        for schema in mappings.mutationSchemata {
+            XCTAssertTrue(
+                rewritten.contains(schema.id),
+                "Rewritten source must contain a mutation switch for schemata "
+                + "'\(schema.id)' but it was not found. The inner mutation was "
+                + "silently dropped during rewriting."
+            )
+        }
+    }
 }

--- a/Tests/MutationSchemata/__Snapshots__/RewriterTests/test_allOperatorsWithImplicitReturnSourceCode.1.txt
+++ b/Tests/MutationSchemata/__Snapshots__/RewriterTests/test_allOperatorsWithImplicitReturnSourceCode.1.txt
@@ -169,7 +169,15 @@ struct ConditionalOperators {
       != nil
     {
     } else {
-      _ = foo(bar: { $0 == char })
+      _ = foo(bar: {
+        if ProcessInfo.processInfo.environment[
+          "sampleWithAllOperators_RelationalOperatorReplacement_26_27_586"] != nil
+        {
+          $0 != char
+        } else {
+          $0 == char
+        }
+      })
     }
   }
 }


### PR DESCRIPTION
## Summary

When both an outer and inner code block have mutation targets (any operator, not just RemoveSideEffects), the inner mutation switch is not emitted in the rewritten source. The inner mutant always reports "survived" regardless of test quality.

**Root cause**: `MuterRewriter` applies mutation switches top-down. `MutationSwitch.apply` creates a new syntax tree for the outer code block, which changes all inner `SyntaxIdentifier` values (SwiftSyntax's `SyntaxHashable` is identity-based). The `SchemataMutationMapping` dictionary lookup for inner `CodeBlockItemListSyntax` nodes then fails silently.

**Fix**: Visit children first (bottom-up) via `super.visit(node)`, then apply the outer mutation switch. Inner code blocks are matched while their identifiers still correspond to the dictionary keys. This is a 3-line change in `MuterRewriter.visit(_:)`.

**Evidence**: The existing snapshot for `test_allOperatorsWithImplicitReturnSourceCode` was missing a ROR mutation on `$0 == char` inside `baz()` — the closure was nested inside a RemoveSideEffects target, triggering the same bug. The updated snapshot now includes it.

## Commits

1. **Failing test**: `test_nestedForLoopsProduceMutationSwitchesAtBothLevels` — creates nested for loops with mutation targets at both levels, asserts both schemata IDs appear in rewritten output. Fails without the fix.
2. **Fix + snapshot update**: Bottom-up rewriting in `MuterRewriter`, plus updated snapshot reflecting the newly-emitted inner mutation.

## Test plan

- [x] New test fails without fix, passes with fix
- [x] All 165 unit tests pass (0 failures)
- [x] End-to-end verification: reproduction project with nested for loops now reports 2/2 killed (was 1/2)
- [x] No regressions in existing snapshot tests (snapshot updated to reflect correct output)

Fixes #283