### PR TITLE
Fix: mutation lookup fails when source file is re-parsed on demand

### DIFF
--- a/Sources/muterCore/MutationSchemata/CodeBlockKey.swift
+++ b/Sources/muterCore/MutationSchemata/CodeBlockKey.swift
@@ -1,0 +1,23 @@
+import SwiftSyntax
+
+struct CodeBlockKey: Hashable {
+    let utf8Offset: Int
+    let utf8Length: Int
+    let description: String
+
+    init(_ node: CodeBlockItemListSyntax) {
+        utf8Offset = node.position.utf8Offset
+        utf8Length = node.totalLength.utf8Length
+        description = node.description
+    }
+
+    /// Hash/equality based on position only — stable across re-parses
+    static func == (lhs: CodeBlockKey, rhs: CodeBlockKey) -> Bool {
+        lhs.utf8Offset == rhs.utf8Offset && lhs.utf8Length == rhs.utf8Length
+    }
+
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(utf8Offset)
+        hasher.combine(utf8Length)
+    }
+}

--- a/Sources/muterCore/MutationSchemata/SchemataMutationMapping.swift
+++ b/Sources/muterCore/MutationSchemata/SchemataMutationMapping.swift
@@ -5,7 +5,7 @@ typealias MutationSchemata = [MutationSchema]
 
 final class SchemataMutationMapping {
     let filePath: String
-    fileprivate var mappings: [CodeBlockItemListSyntax: MutationSchemata]
+    fileprivate var mappings: [CodeBlockKey: MutationSchemata]
 
     var count: Int {
         mappings.count
@@ -38,7 +38,7 @@ final class SchemataMutationMapping {
 
     fileprivate init(
         filePath: String = "",
-        mappings: [CodeBlockItemListSyntax: MutationSchemata]
+        mappings: [CodeBlockKey: MutationSchemata]
     ) {
         self.filePath = filePath
         self.mappings = mappings
@@ -48,20 +48,23 @@ final class SchemataMutationMapping {
         _ codeBlockSyntax: CodeBlockItemListSyntax,
         _ schemata: MutationSchema
     ) {
-        mappings[codeBlockSyntax, default: []].append(schemata)
+        let key = CodeBlockKey(codeBlockSyntax)
+        mappings[key, default: []].append(schemata)
     }
 
     func add(
         _ codeBlockSyntax: CodeBlockItemListSyntax,
         _ schemata: MutationSchemata
     ) {
-        mappings[codeBlockSyntax, default: []].append(contentsOf: schemata)
+        let key = CodeBlockKey(codeBlockSyntax)
+        mappings[key, default: []].append(contentsOf: schemata)
     }
 
     func schemata(
         _ codeBlockSyntax: CodeBlockItemListSyntax
     ) -> MutationSchemata? {
-        mappings[codeBlockSyntax]
+        let key = CodeBlockKey(codeBlockSyntax)
+        return mappings[key]
     }
 }
 
@@ -75,7 +78,8 @@ extension SchemataMutationMapping: Codable {
         let container = try decoder.container(keyedBy: CodingKeys.self)
 
         let schematas = try container.decode([MutationSchema].self, forKey: .mappings)
-        let mappings = [CodeBlockItemListSyntax([]): schematas]
+        let key = CodeBlockKey(CodeBlockItemListSyntax([]))
+        let mappings = [key: schematas]
         let filePath = try container.decode(String.self, forKey: .filePath)
 
         self.init(
@@ -106,14 +110,11 @@ func + (
     lhs: SchemataMutationMapping,
     rhs: SchemataMutationMapping
 ) -> SchemataMutationMapping {
-    let result = SchemataMutationMapping(
-        filePath: lhs.filePath
-    )
+    let result = SchemataMutationMapping(filePath: lhs.filePath)
 
-    let mergedMappgins = lhs.mappings.merging(rhs.mappings) { $0 + $1 }
-
-    for (codeBlock, schemata) in mergedMappgins {
-        result.add(codeBlock, schemata)
+    let merged = lhs.mappings.merging(rhs.mappings) { $0 + $1 }
+    for (key, schemata) in merged {
+        result.mappings[key, default: []].append(contentsOf: schemata)
     }
 
     return result
@@ -140,26 +141,21 @@ extension SchemataMutationMapping: CustomStringConvertible, CustomDebugStringCon
     var debugDescription: String { description }
 
     var description: String {
-        let description = mappings.keys.sorted().reduce(into: "") { accum, key in
-            accum +=
-                """
-                source: "\(key.escapedDescription)",
-                schemata: \(mappings[key]!)
-                """
-        }
+        let description = mappings.keys.sorted(by: { $0.description < $1.description })
+            .reduce(into: "") { accum, key in
+                accum +=
+                    """
+                    source: "\(key.description.replacingOccurrences(of: "\n", with: "\\n").replacingOccurrences(
+                        of: "\"",
+                        with: "\\\""
+                    ))",
+                    schemata: \(mappings[key]!)
+                    """
+            }
         return """
         SchemataMutationMapping(
             \(description)
         )
         """
-    }
-}
-
-extension CodeBlockItemListSyntax: @retroactive Comparable {
-    public static func < (
-        lhs: SwiftSyntax.CodeBlockItemListSyntax,
-        rhs: SwiftSyntax.CodeBlockItemListSyntax
-    ) -> Bool {
-        lhs.description < rhs.description
     }
 }

--- a/Tests/MutationSchemata/SchemataMutationMappingTests.swift
+++ b/Tests/MutationSchemata/SchemataMutationMappingTests.swift
@@ -1,0 +1,102 @@
+@testable import muterCore
+import SwiftParser
+import SwiftSyntax
+import XCTest
+
+final class SchemataMutationMappingTests: MuterTestCase {
+
+    func test_schemataLookupSucceedsAfterReparse() throws {
+        // Given: a mapping created from one parse of the source
+        let source = """
+            func example() {
+                if value < threshold {
+                    expand()
+                }
+            }
+            """
+
+        let firstParse = Parser.parse(source: source)
+        let firstCodeBlock = findFirstCodeBlock(in: firstParse)!
+
+        let mapping = SchemataMutationMapping(filePath: "/path/to/file.swift")
+        let schema = try MutationSchema.make(
+            filePath: "/path/to/file.swift",
+            mutationOperatorId: .ror,
+            syntaxMutation: "\n  if value > threshold {\n      expand()\n  }\n",
+            position: MutationPosition(
+                utf8Offset: firstCodeBlock.position.utf8Offset,
+                line: 2
+            )
+        )
+        mapping.add(firstCodeBlock, schema)
+
+        // When: the same source is re-parsed (simulating ApplySchemata's on-demand loading)
+        let secondParse = Parser.parse(source: source)
+        let secondCodeBlock = findFirstCodeBlock(in: secondParse)!
+
+        // Then: lookup with the re-parsed node should still find the schemata
+        XCTAssertNotNil(
+            mapping.schemata(secondCodeBlock),
+            "Schemata lookup should succeed after re-parsing the same file"
+        )
+    }
+
+    func test_schemataLookupStillWorksWithSameTree() throws {
+        // Given: a mapping created from one parse
+        let source = """
+            func example() {
+                if value < threshold {
+                    expand()
+                }
+            }
+            """
+
+        let parsed = Parser.parse(source: source)
+        let codeBlock = findFirstCodeBlock(in: parsed)!
+
+        let mapping = SchemataMutationMapping(filePath: "/path/to/file.swift")
+        let schema = try MutationSchema.make(
+            filePath: "/path/to/file.swift",
+            mutationOperatorId: .ror,
+            syntaxMutation: "\n  if value > threshold {\n      expand()\n  }\n",
+            position: MutationPosition(
+                utf8Offset: codeBlock.position.utf8Offset,
+                line: 2
+            )
+        )
+        mapping.add(codeBlock, schema)
+
+        // Then: lookup with the same node (same tree) still works
+        XCTAssertNotNil(
+            mapping.schemata(codeBlock),
+            "Schemata lookup should succeed with the original node"
+        )
+    }
+
+    // MARK: - Helpers
+
+    private func findFirstCodeBlock(in source: SourceFileSyntax) -> CodeBlockItemListSyntax? {
+        var result: CodeBlockItemListSyntax?
+        let visitor = CodeBlockFinder { node in
+            if result == nil {
+                result = node
+            }
+        }
+        visitor.walk(source)
+        return result
+    }
+}
+
+private class CodeBlockFinder: SyntaxVisitor {
+    private let handler: (CodeBlockItemListSyntax) -> Void
+
+    init(_ handler: @escaping (CodeBlockItemListSyntax) -> Void) {
+        self.handler = handler
+        super.init(viewMode: .sourceAccurate)
+    }
+
+    override func visit(_ node: CodeBlockItemListSyntax) -> SyntaxVisitorContinueKind {
+        handler(node)
+        return .skipChildren
+    }
+}


### PR DESCRIPTION
### Problem

When processing large codebases, `ApplySchemata` may re-parse a source file from disk instead of using the cached syntax tree (to avoid memory exhaustion):

```swift
// ApplySchemata.swift
if let cached = state.sourceCodeByFilePath[mutationMap.filePath] {
    sourceCode = cached
} else if let parsed = loadSourceCode(from: mutationMap.filePath) {
    sourceCode = parsed  // ← new tree, new node identities
}
```

When this happens, `MuterRewriter` visits nodes from the **new** syntax tree, but `SchemataMutationMapping` was built with nodes from the **original** parse. Since `CodeBlockItemListSyntax` hash/equality is tied to the `SyntaxArena` (not stable across independent parses), **all lookups return `nil`** and no mutations are injected — silently.

### Root cause

`SchemataMutationMapping` uses `[CodeBlockItemListSyntax: MutationSchemata]` as its internal dictionary. SwiftSyntax node identity is not stable across independent `Parser.parse()` calls on the same source.

### Fix

Introduce a `CodeBlockKey` struct that uses `(utf8Offset, utf8Length)` as hash/equality — both values are deterministic for the same source content regardless of which `SyntaxArena` produced the tree.

```swift
struct CodeBlockKey: Hashable {
    let utf8Offset: Int
    let utf8Length: Int
    // ...
}
```

The internal dictionary becomes `[CodeBlockKey: MutationSchemata]` while the public API still accepts `CodeBlockItemListSyntax` parameters.

### Test added

`test_schemataLookupSucceedsAfterReparse` — parses the same source twice, registers a schema with the first tree's node, then verifies lookup succeeds with the second tree's node.

### Related

See #303 which addresses a similar symptom (lost mutations) but for a different scenario: nested mutations within the **same** tree during rewriting. Both fixes are complementary — this PR fixes the **cross-tree** case, #303 fixes the **intra-tree** case.