### PR TITLE
Fix: detect Swift Testing failures in mutation test logs

### DIFF
--- a/Sources/muterCore/TestReporting/TestSuiteOutcome.swift
+++ b/Sources/muterCore/TestReporting/TestSuiteOutcome.swift
@@ -66,7 +66,7 @@ extension TestSuiteOutcome {
     }
 
     private static var testFailureRegEx: NSRegularExpression {
-        NSRegularExpression.regexWithPattern(#"test\(s\)? failed|with ([1-9][0-9]*) failure|with ([1-9][0-9]*) tests? failed"#)
+        NSRegularExpression.regexWithPattern(#"test\(s\)? failed|with ([1-9][0-9]*) (failure|issue)|with ([1-9][0-9]*) tests? failed"#)
     }
 
     private static func terminationStatusIsSuccess(_ terminationStatus: Int32) -> Bool {

--- a/Tests/TestReporting/testSuiteResultParsingTests.swift
+++ b/Tests/TestReporting/testSuiteResultParsingTests.swift
@@ -14,7 +14,7 @@ final class TestSuiteResultParsingTests: MuterTestCase {
     func test_logWithoutFailure() {
         var contents = loadLogFile(named: "testRunWithFailures_withoutTestFailedFooter.log")
         XCTAssertEqual(TestSuiteOutcome.from(testLog: contents, terminationStatus: 0), .failed)
-        
+
         contents = loadLogFile(named: "testRunWithFailures_swift.log")
         XCTAssertEqual(TestSuiteOutcome.from(testLog: contents, terminationStatus: 0), .failed)
 
@@ -68,4 +68,26 @@ final class TestSuiteResultParsingTests: MuterTestCase {
 
         return string
     }
+
+    // MARK: - Swift Testing
+
+    func test_logWithSwiftTestingFailure() {
+        var contents = loadLogFile(named: "testRunWithFailures_swiftTesting.log")
+        XCTAssertEqual(TestSuiteOutcome.from(testLog: contents, terminationStatus: 1), .failed)
+
+        contents = loadLogFile(named: "testRunWithFailures_swiftTesting_multipleIssues.log")
+        XCTAssertEqual(TestSuiteOutcome.from(testLog: contents, terminationStatus: 1), .failed)
+    }
+
+    func test_logWithSwiftTestingSuccess() {
+        let contents = loadLogFile(named: "testRunWithoutFailures_swiftTesting.log")
+        XCTAssertEqual(TestSuiteOutcome.from(testLog: contents, terminationStatus: 0), .passed)
+    }
+
+    func test_logWithSwiftTestingFailureAndExitCodeZero() {
+        // Special case: log says "failed" even if exit code is 0
+        let contents = loadLogFile(named: "testRunWithFailures_swiftTesting.log")
+        XCTAssertEqual(TestSuiteOutcome.from(testLog: contents, terminationStatus: 0), .failed)
+    }
+
 }

--- a/Tests/fixtures/TestLogsForParsing/testRunWithFailures_swiftTesting.log
+++ b/Tests/fixtures/TestLogsForParsing/testRunWithFailures_swiftTesting.log
@@ -1,0 +1,8 @@
+◇ Test run started.
+↳ Testing Library Version: 102 (arm64e-apple-macos15.0)
+◇ Suite SwiftTestingSampleTests started.
+◇ Test sampleTest() started.
+✘ Test sampleTest() recorded an issue at SwiftTestingSampleTests.swift:12:5: Expectation failed: (2 → 2) == 3
+✘ Test sampleTest() failed after 0.001 seconds with 1 issue.
+◇ Suite SwiftTestingSampleTests failed after 0.001 seconds with 1 issue.
+✘ Test run with 1 test failed after 0.001 seconds with 1 issue.

--- a/Tests/fixtures/TestLogsForParsing/testRunWithFailures_swiftTesting_multipleIssues.log
+++ b/Tests/fixtures/TestLogsForParsing/testRunWithFailures_swiftTesting_multipleIssues.log
@@ -1,0 +1,11 @@
+◇ Test run started.
+↳ Testing Library Version: 102 (arm64e-apple-macos15.0)
+◇ Suite MathTests started.
+◇ Test addition() started.
+✘ Test addition() recorded an issue at MathTests.swift:8:5: Expectation failed
+✘ Test addition() failed after 0.001 seconds with 1 issue.
+◇ Test subtraction() started.
+✘ Test subtraction() recorded an issue at MathTests.swift:14:5: Expectation failed
+✘ Test subtraction() failed after 0.001 seconds with 1 issue.
+◇ Suite MathTests failed after 0.003 seconds with 2 issues.
+✘ Test run with 27 tests in 5 suites failed after 0.034 seconds with 6 issues.


### PR DESCRIPTION
### Description

Muter currently fails to recognize test failures reported by Swift Testing. When a mutant is killed by a Swift Testing test, the outcome is incorrectly reported as `runtimeError` instead of `failed` (mutant killed).

### Root cause

Swift Testing uses "with N issue(s)" in its output, while the existing regex only matches XCTest patterns ("failure", "tests? failed"). The multi-suite format introduces "in X suites" between "tests" and "failed", breaking the existing pattern.

Example Swift Testing output not previously matched:

    ✘ Test run with 27 tests in 5 suites failed after 0.034 seconds with 6 issues.

### Fix

Added "issue" as an alternative to "failure" in testFailureRegEx:

    - #"test\(s\)? failed|with ([1-9][0-9]*) (failure)|with ([1-9][0-9]*) tests? failed"#
    + #"test\(s\)? failed|with ([1-9][0-9]*) (failure|issue)|with ([1-9][0-9]*) tests? failed"#

This matches both "with 6 issues" and "with 1 issue" while the [1-9] prefix ensures "with 0 issues" (passing runs) is never matched.

### Tests added

| Fixture | Exit code | Expected | Validates |
|---------|-----------|----------|-----------|
| testRunWithFailures_swiftTesting.log | 1 | .failed | Single test, 1 issue |
| testRunWithFailures_swiftTesting_multipleIssues.log | 1 | .failed | Multi-suite, N issues |
| testRunWithoutFailures_swiftTesting.log | 0 | .passed | No false positive |
| testRunWithFailures_swiftTesting.log | 0 | .failed | Regex detects failure regardless of exit code |

### No breaking changes

Existing XCTest and Buck detection paths are unaffected — all prior tests continue to pass.