### PR TITLE
Fix the 0% score chain: schemata application, nested blocks, ternary corruption, and launch failures

### DIFF
--- a/Sources/muterCore/BuildSystems/BuildSystem.swift
+++ b/Sources/muterCore/BuildSystems/BuildSystem.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-enum BuildSystem: String {
+enum BuildSystem: String, Codable, Equatable {
     case xcodebuild
     case swift
     case unknown

--- a/Sources/muterCore/BuildSystems/Xcode/XCTestRun.swift
+++ b/Sources/muterCore/BuildSystems/Xcode/XCTestRun.swift
@@ -59,13 +59,17 @@ struct XCTestRun: Equatable {
         let environmentVariablesKey = "EnvironmentVariables"
         var configuration = configuration
 
-        if configuration.keys.contains(environmentVariablesKey),
-           var allEnvironmentVariables = configuration[environmentVariablesKey] as? [String: AnyHashable] {
-            allEnvironmentVariables[key] = isMuterRunningValue
-            allEnvironmentVariables[isMuterRunningKey] = isMuterRunningValue
+        // Create the `EnvironmentVariables` dict when absent instead of skipping. A freshly generated
+        // .xctestrun has no such dict for a target, so the old `keys.contains` guard silently never
+        // wrote the schemata activation var. On the `test-without-building -xctestrun` path (used for
+        // simulator-hosted targets, where the env must ride in via the xctestrun rather than the parent
+        // process) the mutant then never activated in the test host — every mutant became a false
+        // "survived", i.e. a phantom 0% score.
+        var allEnvironmentVariables = configuration[environmentVariablesKey] as? [String: AnyHashable] ?? [:]
+        allEnvironmentVariables[key] = isMuterRunningValue
+        allEnvironmentVariables[isMuterRunningKey] = isMuterRunningValue
 
-            configuration[environmentVariablesKey] = allEnvironmentVariables
-        }
+        configuration[environmentVariablesKey] = allEnvironmentVariables
 
         return configuration
     }

--- a/Sources/muterCore/Configuration/MuterConfiguration.swift
+++ b/Sources/muterCore/Configuration/MuterConfiguration.swift
@@ -80,6 +80,21 @@ struct MuterConfiguration: Equatable, Codable {
 }
 
 extension MuterConfiguration {
+    /// A copy of this configuration whose test command runs `executable`.
+    func withExecutable(_ executable: String) -> MuterConfiguration {
+        MuterConfiguration(
+            executable: executable,
+            arguments: testCommandArguments,
+            excludeList: excludeFileList,
+            excludeCallList: excludeCallList,
+            coverageThreshold: coverageThreshold,
+            testSuiteTimeOut: testSuiteTimeout,
+            buildSystem: explicitBuildSystem
+        )
+    }
+}
+
+extension MuterConfiguration {
     static let fileName = "muter.conf"
     static let `extension` = "yml"
     static let fileNameWithExtension = "\(fileName).\(`extension`)"

--- a/Sources/muterCore/Configuration/MuterConfiguration.swift
+++ b/Sources/muterCore/Configuration/MuterConfiguration.swift
@@ -10,8 +10,16 @@ struct MuterConfiguration: Equatable, Codable {
     let excludeCallList: [String]
     let coverageThreshold: Double
     let testSuiteTimeout: Double?
+    /// Optional explicit build system from the `buildSystem:` config key. When set it overrides the
+    /// executable-basename heuristic — needed when `executable` is a wrapper script (e.g. one that
+    /// restores env / forwards SIMCTL_CHILD_ vars) whose filename isn't literally `xcodebuild`/`swift`.
+    let explicitBuildSystem: BuildSystem?
 
     var buildSystem: BuildSystem {
+        if let explicitBuildSystem, explicitBuildSystem != .unknown {
+            return explicitBuildSystem
+        }
+
         guard let buildSystem = testCommandExecutable.components(separatedBy: "/").last?.trimmed else {
             return .unknown
         }
@@ -26,6 +34,7 @@ struct MuterConfiguration: Equatable, Codable {
         case excludeCallList = "excludeCalls"
         case coverageThreshold
         case testSuiteTimeout = "mutationTestTimeout"
+        case explicitBuildSystem = "buildSystem"
     }
 
     init(
@@ -34,7 +43,8 @@ struct MuterConfiguration: Equatable, Codable {
         excludeList: [String] = [],
         excludeCallList callList: [String] = [],
         coverageThreshold threshold: Double = 0,
-        testSuiteTimeOut timeout: Double? = nil
+        testSuiteTimeOut timeout: Double? = nil,
+        buildSystem: BuildSystem? = nil
     ) {
         testCommandExecutable = executable
         testCommandArguments = arguments
@@ -42,6 +52,7 @@ struct MuterConfiguration: Equatable, Codable {
         excludeCallList = callList
         coverageThreshold = threshold
         testSuiteTimeout = timeout
+        explicitBuildSystem = buildSystem
     }
 
     init(from decoder: Decoder) throws {
@@ -55,6 +66,8 @@ struct MuterConfiguration: Equatable, Codable {
         coverageThreshold = container.decode(Double.self, default: 0, forKey: .coverageThreshold)
         testSuiteTimeout = try container.decodeIfPresent(Double.self, forKey: .testSuiteTimeout)
             ?? (try container.decodeIfPresent(Int.self, forKey: .testSuiteTimeout)).flatMap(Double.init)
+        explicitBuildSystem = (try container.decodeIfPresent(String.self, forKey: .explicitBuildSystem))
+            .map(BuildSystem.init(rawValue:))
     }
 
     init(from data: Data) throws {

--- a/Sources/muterCore/MutationOperators/SwapTernaryOperator.swift
+++ b/Sources/muterCore/MutationOperators/SwapTernaryOperator.swift
@@ -88,6 +88,16 @@ enum SwapTernaryOperator {
                 return node
             }
 
+            // Only swap when the else-expression is a SINGLE trailing child (`… ? a : b`, so the
+            // ternary is at `index` and `b` at `index + 1`, the last element). When the else-expression
+            // is itself a comparison/sequence (`… ? a : c < d`), SwiftSyntax flattens `c < d` into
+            // multiple sibling children of the outer SequenceExpr; swapping would take only `c` and
+            // leave `< d` dangling, producing `x < y < d` — adjacent operators in a non-associative
+            // precedence group, a compile error. Skip rather than emit invalid code.
+            guard children.count == index + 2 else {
+                return node
+            }
+
             let secondChoice = children[index + 1]
                 .withTrailingTrivia(.spaces(1))
                 .withLeadingTrivia(.spaces(1))

--- a/Sources/muterCore/MutationSchemata/SchemataMutationMapping.swift
+++ b/Sources/muterCore/MutationSchemata/SchemataMutationMapping.swift
@@ -3,9 +3,35 @@ import SwiftSyntax
 
 typealias MutationSchemata = [MutationSchema]
 
+/// A key that identifies a code block by its STABLE source position (the UTF-8 byte offset of its
+/// first token) plus its text, rather than by SwiftSyntax node identity.
+///
+/// The mapping used to be keyed by `CodeBlockItemListSyntax` directly, but `Syntax` hashes on
+/// `SyntaxIdentifier` — i.e. node IDENTITY, tied to a specific parse tree. `ApplySchemata` re-parses
+/// each source file (on-demand re-parsing avoids memory exhaustion on large codebases), producing
+/// fresh node identities, so the rewriter's lookup never matched what discovery inserted — schemata
+/// were silently never applied and every mutant was reported as "survived" (0% score). Two parses of
+/// the same bytes yield the same offset + text, so this key is stable across re-parsing.
+struct CodeBlockKey: Hashable {
+    let offset: Int
+    let text: String
+
+    init(_ node: CodeBlockItemListSyntax) {
+        offset = node.positionAfterSkippingLeadingTrivia.utf8Offset
+        text = node.description
+    }
+
+    init(offset: Int, text: String) {
+        self.offset = offset
+        self.text = text
+    }
+}
+
 final class SchemataMutationMapping {
     let filePath: String
-    fileprivate var mappings: [CodeBlockItemListSyntax: MutationSchemata]
+    fileprivate var mappings: [CodeBlockKey: MutationSchemata]
+    // Preserves the code-block text for each key so `codeBlocks` / `description` keep reporting source.
+    fileprivate var codeBlockText: [CodeBlockKey: String]
 
     var count: Int {
         mappings.count
@@ -20,7 +46,7 @@ final class SchemataMutationMapping {
     }
 
     var codeBlocks: [String] {
-        mappings.keys.map(\.description).sorted()
+        mappings.keys.compactMap { codeBlockText[$0] }.sorted()
     }
 
     var fileName: String {
@@ -32,36 +58,53 @@ final class SchemataMutationMapping {
     ) {
         self.init(
             filePath: filePath,
-            mappings: [:]
+            mappings: [:],
+            codeBlockText: [:]
         )
     }
 
     fileprivate init(
         filePath: String = "",
-        mappings: [CodeBlockItemListSyntax: MutationSchemata]
+        mappings: [CodeBlockKey: MutationSchemata],
+        codeBlockText: [CodeBlockKey: String] = [:]
     ) {
         self.filePath = filePath
         self.mappings = mappings
+        self.codeBlockText = codeBlockText
     }
 
     func add(
         _ codeBlockSyntax: CodeBlockItemListSyntax,
         _ schemata: MutationSchema
     ) {
-        mappings[codeBlockSyntax, default: []].append(schemata)
+        let key = CodeBlockKey(codeBlockSyntax)
+        codeBlockText[key] = codeBlockSyntax.description
+        mappings[key, default: []].append(schemata)
     }
 
     func add(
         _ codeBlockSyntax: CodeBlockItemListSyntax,
         _ schemata: MutationSchemata
     ) {
-        mappings[codeBlockSyntax, default: []].append(contentsOf: schemata)
+        let key = CodeBlockKey(codeBlockSyntax)
+        codeBlockText[key] = codeBlockSyntax.description
+        mappings[key, default: []].append(contentsOf: schemata)
     }
 
     func schemata(
         _ codeBlockSyntax: CodeBlockItemListSyntax
     ) -> MutationSchemata? {
-        mappings[codeBlockSyntax]
+        mappings[CodeBlockKey(codeBlockSyntax)]
+    }
+
+    // Key-based add for merging two mappings without reconstructing a syntax node from text.
+    fileprivate func add(
+        _ key: CodeBlockKey,
+        text: String,
+        _ schemata: MutationSchemata
+    ) {
+        codeBlockText[key] = text
+        mappings[key, default: []].append(contentsOf: schemata)
     }
 }
 
@@ -75,8 +118,15 @@ extension SchemataMutationMapping: Codable {
         let container = try decoder.container(keyedBy: CodingKeys.self)
 
         let schematas = try container.decode([MutationSchema].self, forKey: .mappings)
-        let mappings = [CodeBlockItemListSyntax([]): schematas]
         let filePath = try container.decode(String.self, forKey: .filePath)
+
+        // Re-key each decoded schema by its own stable source offset rather than collapsing them all
+        // under one empty-block key (which previously merged every schema into a single mapping entry).
+        var mappings: [CodeBlockKey: MutationSchemata] = [:]
+        for schema in schematas {
+            let key = CodeBlockKey(offset: schema.position.utf8Offset, text: schema.snapshot.before)
+            mappings[key, default: []].append(schema)
+        }
 
         self.init(
             filePath: filePath,
@@ -110,10 +160,11 @@ func + (
         filePath: lhs.filePath
     )
 
-    let mergedMappgins = lhs.mappings.merging(rhs.mappings) { $0 + $1 }
+    let mergedMappings = lhs.mappings.merging(rhs.mappings) { $0 + $1 }
+    let mergedText = lhs.codeBlockText.merging(rhs.codeBlockText) { current, _ in current }
 
-    for (codeBlock, schemata) in mergedMappgins {
-        result.add(codeBlock, schemata)
+    for (key, schemata) in mergedMappings {
+        result.add(key, text: mergedText[key] ?? key.text, schemata)
     }
 
     return result
@@ -141,9 +192,12 @@ extension SchemataMutationMapping: CustomStringConvertible, CustomDebugStringCon
 
     var description: String {
         let description = mappings.keys.sorted().reduce(into: "") { accum, key in
+            let source = (codeBlockText[key] ?? key.text)
+                .replacingOccurrences(of: "\n", with: "\\n")
+                .replacingOccurrences(of: "\"", with: "\\\"")
             accum +=
                 """
-                source: "\(key.escapedDescription)",
+                source: "\(source)",
                 schemata: \(mappings[key]!)
                 """
         }
@@ -155,11 +209,8 @@ extension SchemataMutationMapping: CustomStringConvertible, CustomDebugStringCon
     }
 }
 
-extension CodeBlockItemListSyntax: @retroactive Comparable {
-    public static func < (
-        lhs: SwiftSyntax.CodeBlockItemListSyntax,
-        rhs: SwiftSyntax.CodeBlockItemListSyntax
-    ) -> Bool {
-        lhs.description < rhs.description
+extension CodeBlockKey: Comparable {
+    static func < (lhs: CodeBlockKey, rhs: CodeBlockKey) -> Bool {
+        lhs.text < rhs.text
     }
 }

--- a/Sources/muterCore/MutationSteps/CopyProjectToTempDirectory.swift
+++ b/Sources/muterCore/MutationSteps/CopyProjectToTempDirectory.swift
@@ -5,6 +5,10 @@ class CopyProjectToTempDirectory: MutationStep {
     private var fileManager: FileSystemManager
     @Dependency(\.notificationCenter)
     private var notificationCenter: NotificationCenter
+    @Dependency(\.process)
+    private var process: ProcessFactory
+
+    private let moduleCacheDirectoryName = "ModuleCache"
 
     func run(
         with state: AnyMutationTestState
@@ -20,6 +24,8 @@ class CopyProjectToTempDirectory: MutationStep {
                 toPath: state.mutatedProjectDirectoryURL.path
             )
 
+            discardModuleCaches(in: state.mutatedProjectDirectoryURL)
+
             notificationCenter.post(
                 name: .projectCopyFinished,
                 object: state.mutatedProjectDirectoryURL.path
@@ -30,6 +36,22 @@ class CopyProjectToTempDirectory: MutationStep {
             throw MuterError.projectCopyFailed(
                 reason: error.localizedDescription
             )
+        }
+    }
+
+    /// Clang module caches record the absolute path they were built under. Copied alongside the rest of
+    /// a project's build directory they no longer match where they now live, and every compile in the
+    /// copy fails with `precompiled file … was compiled with module cache path …` followed by
+    /// `missing required module 'SwiftShims'`. Discarding them keeps the rest of the build directory
+    /// warm — the compiler rebuilds the caches in place on the next compile.
+    private func discardModuleCaches(in directory: URL) {
+        let caches = process()
+            .find(atPath: directory.path, byName: moduleCacheDirectoryName)?
+            .split(separator: "\n")
+            .map(String.init) ?? []
+
+        for cache in caches {
+            try? fileManager.removeItem(atPath: cache)
         }
     }
 }

--- a/Sources/muterCore/MutationSteps/LoadConfiguration.swift
+++ b/Sources/muterCore/MutationSteps/LoadConfiguration.swift
@@ -3,6 +3,8 @@ import Foundation
 struct LoadConfiguration: MutationStep {
     @Dependency(\.fileManager)
     private var fileManager: FileSystemManager
+    @Dependency(\.process)
+    private var process: ProcessFactory
 
     func run(
         with state: AnyMutationTestState
@@ -38,11 +40,45 @@ struct LoadConfiguration: MutationStep {
 
             return [
                 .projectDirectoryUrlDiscovered(URL(fileURLWithPath: fileManager.currentDirectoryPath)),
-                .configurationParsed(configuration),
+                .configurationParsed(try withResolvedExecutable(configuration)),
             ]
+        } catch let error as MuterError {
+            throw error
         } catch {
             throw MuterError.configurationParsingError(reason: "\(error)")
         }
+    }
+
+    /// Turns a bare command name in `executable` into the absolute path it resolves to on `PATH`.
+    ///
+    /// A name with no path separator — `swift`, `xcodebuild` — only means anything to a shell, which
+    /// searches `PATH` for it. Muter spawns the test command with `Process`, and `Process.executableURL`
+    /// resolves a name that isn't an absolute path against the *current working directory*. Later steps
+    /// run from the mutated copy of the project, where no such file exists, so the test process fails to
+    /// spawn before it can emit a single line. Resolving here — while the working directory is still the
+    /// project root — gives every later step an executable it can actually launch.
+    private func withResolvedExecutable(
+        _ configuration: MuterConfiguration
+    ) throws -> MuterConfiguration {
+        let executable = configuration.testCommandExecutable
+        guard !executable.contains("/") else {
+            return configuration
+        }
+
+        // Reported verbatim rather than as a `configurationParsingError`: the file parsed fine, so framing
+        // this as a parsing or FileManager problem would send the user looking in the wrong place.
+        guard let resolved = process().which(executable) else {
+            throw MuterError.literal(
+                reason: """
+                Muter could not find "\(executable)" on your PATH.
+
+                The "executable" option in \(MuterConfiguration.fileNameWithExtension) must name a command \
+                that exists on your PATH, or be an absolute path such as "/usr/bin/\(executable)".
+                """
+            )
+        }
+
+        return configuration.withExecutable(resolved)
     }
 
     private func configurationPath(_ options: Run.Options) -> String {

--- a/Sources/muterCore/MutationSteps/PerformMutationTesting.swift
+++ b/Sources/muterCore/MutationSteps/PerformMutationTesting.swift
@@ -69,18 +69,29 @@ private extension PerformMutationTesting {
             end: timeAfterRunningTestSuite
         ).duration
 
-        guard testSuiteOutcome == .passed else {
-            throw MuterError.mutationTestingAborted(
-                reason: .baselineTestFailed(log: testLog)
-            )
-        }
-
         let mutationLog = MutationTestLog(
             mutationPoint: .none,
             testLog: testLog,
             timePerBuildTestCycle: timePerBuildTestCycle,
             remainingMutationPointsCount: state.mutationPoints.count
         )
+
+        guard testSuiteOutcome == .passed else {
+            // A failing baseline is exactly when the user needs its output on disk, and nothing else
+            // records it. It gets its own notification rather than `.newTestLogAvailable`, which also
+            // announces that a baseline was successfully determined and starts the progress bar.
+            notificationCenter.post(
+                name: .baselineTestFailed,
+                object: mutationLog
+            )
+
+            throw MuterError.mutationTestingAborted(
+                reason: .baselineTestFailed(
+                    log: testLog,
+                    mutatedFilePaths: state.mutationMapping.map(\.filePath)
+                )
+            )
+        }
 
         notificationCenter.post(
             name: .newTestLogAvailable,

--- a/Sources/muterCore/MutationTesting/MutationTestObserver.swift
+++ b/Sources/muterCore/MutationTesting/MutationTestObserver.swift
@@ -30,6 +30,7 @@ extension Notification.Name {
 
     static let newMutationTestOutcomeAvailable = Notification.Name("newMutationTestOutcomeAvailable")
     static let newTestLogAvailable = Notification.Name("newTestLogAvailable")
+    static let baselineTestFailed = Notification.Name("baselineTestFailed")
 
     static let configurationFileCreated = Notification.Name("configurationFileCreated")
 
@@ -75,6 +76,7 @@ final class MutationTestObserver {
 
             (name: .newMutationTestOutcomeAvailable, handler: handleNewMutationTestOutcomeAvailable),
             (name: .newTestLogAvailable, handler: handleNewTestLogAvailable),
+            (name: .baselineTestFailed, handler: handleBaselineTestFailed),
 
             (name: .mutationTestingFinished, handler: handleMutationTestingFinished),
 
@@ -176,6 +178,16 @@ extension MutationTestObserver {
 
         logger.newMutationTestLogAvailable(mutationTestLog: mutationTestLog)
 
+        writeTestLog(mutationTestLog)
+    }
+
+    /// Records the log only. The abort message reports the failure to the console, and there is no
+    /// progress left to announce.
+    func handleBaselineTestFailed(notification: Notification) {
+        writeTestLog(notification.object as! MutationTestLog)
+    }
+
+    private func writeTestLog(_ mutationTestLog: MutationTestLog) {
         _ = fileManager.createFile(
             atPath: "\(loggingDirectory)/\(logFileName(from: mutationTestLog.mutationPoint))",
             contents: mutationTestLog.testLog.data(using: .utf8),

--- a/Sources/muterCore/MutationTesting/MutationTestingAbortReason.swift
+++ b/Sources/muterCore/MutationTesting/MutationTestingAbortReason.swift
@@ -1,5 +1,10 @@
+import Foundation
+
 public enum MutationTestingAbortReason: Equatable {
-    case baselineTestFailed(log: String)
+    /// `mutatedFilePaths` are the files Muter rewrote to insert mutants. A compile error in one of
+    /// them points at Muter's own rewriting rather than at the user's configuration, so the message
+    /// needs them to tell the two apart.
+    case baselineTestFailed(log: String, mutatedFilePaths: [String])
     case tooManyBuildErrors
     case unknownError(description: String)
 }
@@ -7,23 +12,11 @@ public enum MutationTestingAbortReason: Equatable {
 extension MutationTestingAbortReason: CustomStringConvertible {
     public var description: String {
         switch self {
-        case let .baselineTestFailed(log):
-            return """
-            Muter noticed that your test suite initially failed to compile or produced a test failure.
-
-            Assuming you have no build errors, this is usually due to misconfiguring the "executable" and "arguments" options inside of your \(
-                MuterConfiguration
-                    .fileName
-            ).
-            Alternatively, it could mean you have a nondeterministic test failure in your test suite.
-
-            We recommend you try your settings out in a terminal prior to using Muter for the best configuration experience.
-            We also recommend removing tests which you know are flaky from the set of tests that Muter exercises.
-
-            Here's the log XCTest produced:
-
-            \(log)
-            """
+        case let .baselineTestFailed(log, mutatedFilePaths):
+            return Self.baselineTestFailedDescription(
+                log: log,
+                mutatedFilePaths: mutatedFilePaths
+            )
 
         case .tooManyBuildErrors:
             return """
@@ -35,5 +28,128 @@ extension MutationTestingAbortReason: CustomStringConvertible {
         case let .unknownError(error):
             return "Muter encountered an error running your test suite and can't continue\n\(error)"
         }
+    }
+}
+
+private extension MutationTestingAbortReason {
+    static func baselineTestFailedDescription(
+        log: String,
+        mutatedFilePaths: [String]
+    ) -> String {
+        """
+        \(baselineTestFailedCause(log: log, mutatedFilePaths: mutatedFilePaths))
+
+        \(baselineTestFailedEvidence(log: log))
+        """
+    }
+
+    static func baselineTestFailedCause(
+        log: String,
+        mutatedFilePaths: [String]
+    ) -> String {
+        if let error = CompilerError.first(in: log, inFilesAt: mutatedFilePaths) {
+            return """
+            Muter could not establish a baseline because a file it had mutated failed to compile:
+
+              \(error.description)
+
+            Muter rewrites the files it mutates before running your test suite, so a compile error in \
+            \(error.fileName) is most likely a bug in Muter's own rewriting rather than a problem with \
+            your \(MuterConfiguration.fileNameWithExtension).
+
+            Please report this at https://github.com/muter-mutation-testing/muter/issues/ and include \
+            the log below. To rule out a pre-existing error, check that \(error.fileName) compiles in \
+            your unmutated project.
+            """
+        }
+
+        return """
+        Muter noticed that your test suite initially failed to compile or produced a test failure.
+
+        Assuming you have no build errors, this is usually due to misconfiguring the "executable" and \
+        "arguments" options inside of your \(MuterConfiguration.fileName).
+        Alternatively, it could mean you have a nondeterministic test failure in your test suite.
+
+        We recommend you try your settings out in a terminal prior to using Muter for the best configuration experience.
+        We also recommend removing tests which you know are flaky from the set of tests that Muter exercises.
+        """
+    }
+
+    static func baselineTestFailedEvidence(log: String) -> String {
+        guard !log.trimmed.isEmpty else {
+            return """
+            Muter captured no output at all from your test command, so it has no log to show. That \
+            normally means the command never started — check that "executable" in \
+            \(MuterConfiguration.fileNameWithExtension) names a command Muter can launch.
+            """
+        }
+
+        return """
+        Here's the log your test command produced:
+
+        \(log)
+        """
+    }
+}
+
+/// A `file:line:column: error: message` diagnostic parsed out of a compiler or test log.
+struct CompilerError: Equatable {
+    let filePath: String
+    let line: Int
+    let column: Int
+    let message: String
+
+    var fileName: String {
+        filePath.lastPathComponent
+    }
+
+    var description: String {
+        "\(fileName):\(line):\(column): error: \(message)"
+    }
+}
+
+extension CompilerError {
+    /// The first compile error in `log` reported against any of `filePaths`.
+    ///
+    /// Matching is by file name rather than full path: the log's paths point into Muter's copy of the
+    /// project, while the paths Muter records for its mutants are relative to the original.
+    static func first(
+        in log: String,
+        inFilesAt filePaths: [String]
+    ) -> CompilerError? {
+        let fileNames = Set(filePaths.map(\.lastPathComponent))
+
+        return all(in: log).first { fileNames.contains($0.fileName) }
+    }
+
+    static func all(in log: String) -> [CompilerError] {
+        log.split(separator: "\n").compactMap { from(logLine: String($0)) }
+    }
+
+    /// Parses one `/path/to/File.swift:12:34: error: expected expression` line. The message runs to the
+    /// end of the line; anything that doesn't have exactly this shape is not a diagnostic.
+    private static func from(logLine: String) -> CompilerError? {
+        let components = logLine.split(separator: ":", maxSplits: 4, omittingEmptySubsequences: false)
+        guard components.count == 5,
+              let line = Int(components[1]),
+              let column = Int(components[2]),
+              String(components[3]).trimmed == "error",
+              !String(components[4]).trimmed.isEmpty
+        else {
+            return nil
+        }
+
+        return CompilerError(
+            filePath: String(components[0]),
+            line: line,
+            column: column,
+            message: String(components[4]).trimmed
+        )
+    }
+}
+
+private extension String {
+    var lastPathComponent: String {
+        URL(fileURLWithPath: self).lastPathComponent
     }
 }

--- a/Sources/muterCore/MutationTesting/MutationTestingIODelegate.swift
+++ b/Sources/muterCore/MutationTesting/MutationTestingIODelegate.swift
@@ -126,7 +126,8 @@ struct MutationTestingDelegate: MutationTestingIODelegate {
             process.waitUntilExit()
             return .success
         } timeoutHandler: {
-            process.interrupt()
+            // Kill the whole process tree, not just the launched command — see terminateTree().
+            process.terminateTree()
             return .timeout
         }
     }

--- a/Sources/muterCore/MutationTesting/MutationTestingIODelegate.swift
+++ b/Sources/muterCore/MutationTesting/MutationTestingIODelegate.swift
@@ -94,7 +94,22 @@ struct MutationTestingDelegate: MutationTestingIODelegate {
             )
 
         } catch {
-            return (.buildError, "") // this should never be executed
+            // Reaching here means the test command never ran — the log file couldn't be opened, or
+            // the process failed to spawn. There is no test output to report, so the thrown error is
+            // the only evidence of what went wrong; return it as the log rather than an empty string,
+            // which leaves the caller with nothing to show the user.
+            return (
+                .buildError,
+                """
+                Muter could not run your test command and captured no test output.
+
+                  executable: \(configuration.testCommandExecutable)
+                  arguments: \(configuration.testCommandArguments.joined(separator: " "))
+                  working directory: \(FileManager.default.currentDirectoryPath)
+
+                \(error.localizedDescription)
+                """
+            )
         }
     }
 

--- a/Sources/muterCore/MutationTesting/MutationTestingIODelegate.swift
+++ b/Sources/muterCore/MutationTesting/MutationTestingIODelegate.swift
@@ -170,8 +170,19 @@ struct MutationTestingDelegate: MutationTestingIODelegate {
 
         let process = process()
 
+        // Set the muter marker only on the TEST process, not the shared build process (see
+        // MuterProcessFactory) — it's not needed at build time and setting it there can suppress
+        // xcodebuild's build-request.json.
+        process.environment?[isMuterRunningKey] = isMuterRunningValue
+
         if schemata != .null {
             process.environment?[schemata.id] = "YES"
+            // Also forward the activation var into an iOS Simulator test host. When xcodebuild spawns
+            // tests in the simulator, CoreSimulator only propagates env vars prefixed `SIMCTL_CHILD_`
+            // into the simulated process; a bare var set on this (parent) process never reaches the
+            // test host, so the mutant wouldn't activate. Harmless for non-simulator (swift/macOS) runs,
+            // which read the bare var directly. Complements the xctestrun `EnvironmentVariables` path.
+            process.environment?["SIMCTL_CHILD_\(schemata.id)"] = "YES"
         }
 
         process.arguments = testCommandArguments

--- a/Sources/muterCore/Rewriters/MuterRewriter.swift
+++ b/Sources/muterCore/Rewriters/MuterRewriter.swift
@@ -12,11 +12,19 @@ final class MuterRewriter: SyntaxRewriter {
             return super.visit(node)
         }
 
-        let newNode = MutationSwitch.apply(
-            mutationSchemata: mutationSchemata,
-            with: node
-        )
+        // Rewrite the CHILDREN first, on the original node, then wrap the result.
+        //
+        // Applying the switch first and visiting the synthesized node loses every nested code block's
+        // mutants: wrapping shifts the nested blocks' source positions, so their mapping entries no
+        // longer match and their switches are silently never inserted. A closure or ternary body
+        // therefore had mutants discovered and then dropped. Visiting the original node keeps the
+        // nested positions the discovery pass recorded, and the rewritten children become the switch's
+        // default branch.
+        let childrenRewritten = super.visit(node)
 
-        return super.visit(newNode)
+        return MutationSwitch.apply(
+            mutationSchemata: mutationSchemata,
+            with: childrenRewritten
+        )
     }
 }

--- a/Sources/muterCore/Shell/MuterProcess.swift
+++ b/Sources/muterCore/Shell/MuterProcess.swift
@@ -3,6 +3,7 @@ import Foundation
 typealias Process = MuterProcess
 
 protocol MuterProcess: AnyObject {
+    var processIdentifier: Int32 { get }
     var terminationStatus: Int32 { get }
     var terminationHandler: (@Sendable (Foundation.Process) -> Void)? { get set }
     var environment: [String: String]? { get set }
@@ -21,11 +22,57 @@ protocol MuterProcess: AnyObject {
     func waitUntilExit()
 
     func terminate()
-    
+
     func interrupt()
+
+    /// SIGKILL this process and every transitive descendant (default impl walks `ps`). Declared here
+    /// so it dynamically dispatches to conformers/test doubles rather than binding statically.
+    func terminateTree()
 }
 
 extension MuterProcess {
+    /// SIGKILL this process and every transitive descendant. `interrupt()`/`terminate()` signal only
+    /// the launched command (`swift test` / `xcodebuild`), not the test-runner grandchildren it spawns
+    /// (`swiftpm-testing-helper`, `xctest`); those survive, keep spinning at ~100% CPU, and accumulate
+    /// across mutants until they starve the machine. Walk parent→child links via `ps` and kill the
+    /// whole tree so a timed-out mutant's test leaves nothing behind.
+    func terminateTree() {
+        let root = processIdentifier
+        guard root > 0 else { return }
+        for pid in Self.descendantPIDs(of: root) + [root] {
+            kill(pid, SIGKILL)
+        }
+    }
+
+    /// All transitive child PIDs of `root`, discovered from `ps -eo pid,ppid`.
+    private static func descendantPIDs(of root: Int32) -> [Int32] {
+        let ps = Foundation.Process()
+        ps.executableURL = URL(fileURLWithPath: "/bin/ps")
+        ps.arguments = ["-eo", "pid,ppid"]
+        let pipe = Pipe()
+        ps.standardOutput = pipe
+        guard (try? ps.run()) != nil else { return [] }
+        ps.waitUntilExit()
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        guard let text = String(data: data, encoding: .utf8) else { return [] }
+
+        var childrenByParent: [Int32: [Int32]] = [:]
+        for line in text.split(separator: "\n").dropFirst() {
+            let cols = line.split(whereSeparator: { $0 == " " }).compactMap { Int32($0) }
+            guard cols.count == 2 else { continue }
+            childrenByParent[cols[1], default: []].append(cols[0])
+        }
+
+        var result: [Int32] = []
+        var queue = childrenByParent[root] ?? []
+        while let pid = queue.first {
+            queue.removeFirst()
+            result.append(pid)
+            queue.append(contentsOf: childrenByParent[pid] ?? [])
+        }
+        return result
+    }
+
     func runProcess(
         url: String,
         arguments: [String]

--- a/Sources/muterCore/Shell/ProcessFactory.swift
+++ b/Sources/muterCore/Shell/ProcessFactory.swift
@@ -8,9 +8,12 @@ enum MuterProcessFactory {
         let process = Foundation.Process()
         process.qualityOfService = .userInteractive
 
-        var environment = ProcessInfo.processInfo.environment
-        environment[isMuterRunningKey] = isMuterRunningValue
-        process.environment = environment
+        // Preserve the parent environment (PATH, DEVELOPER_DIR, …). Do NOT set IS_MUTER_RUNNING here:
+        // this factory also builds the `build-for-testing` process, and on some projects that extra
+        // env var makes xcodebuild skip writing `build-request.json`, breaking BuildForTesting's parse.
+        // Nothing reads IS_MUTER_RUNNING at build time; it's set on the test process (and xctestrun)
+        // where schemata activation lives — see MutationTestingIODelegate.testProcess.
+        process.environment = ProcessInfo.processInfo.environment
 
         return process
     }

--- a/Tests/BuildSystems/XCTestRunTests.swift
+++ b/Tests/BuildSystems/XCTestRunTests.swift
@@ -36,6 +36,40 @@ final class XCTestRunTests: MuterTestCase {
         XCTAssertNotNil(environmentVariables?[isMuterRunningKey])
     }
 
+    func test_updateEnvironmentVariable_createsEnvironmentVariablesWhenAbsent() {
+        // A freshly generated .xctestrun target has no EnvironmentVariables dict. The var must still
+        // be injected (regression: the old keys.contains guard skipped it → phantom 0% on simulator).
+        sut = muterCore.XCTestRun([
+            "SomeTestTarget": ["BlueprintName": "SomeTestTarget"] as [String: AnyHashable]
+        ])
+
+        let actualPlist = sut.updateEnvironmentVariable(setting: "keyToBeSet")
+
+        let target = actualPlist["SomeTestTarget"] as? [String: AnyHashable]
+        let environmentVariables = target?["EnvironmentVariables"] as? [String: AnyHashable]
+        XCTAssertEqual(environmentVariables?["keyToBeSet"], isMuterRunningValue)
+        XCTAssertEqual(environmentVariables?[isMuterRunningKey], isMuterRunningValue)
+    }
+
+    func test_updateEnvironmentVariable_forTestPlan_createsEnvironmentVariablesWhenAbsent() {
+        sut = muterCore.XCTestRun([
+            "TestConfigurations": [
+                ["TestTargets": [["BlueprintName": "SomeTestTarget"] as [String: AnyHashable]]] as [String: AnyHashable]
+            ]
+        ])
+
+        let actualPlist = sut.updateEnvironmentVariable(setting: "keyToBeSet")
+
+        let testConfigurations = actualPlist["TestConfigurations"] as? [AnyHashable]
+        let testConfiguration = testConfigurations?.first as? [String: AnyHashable]
+        let testTargets = testConfiguration?["TestTargets"] as? [AnyHashable]
+        let testTarget = testTargets?.first as? [String: AnyHashable]
+        let environmentVariables = testTarget?["EnvironmentVariables"] as? [String: AnyHashable]
+
+        XCTAssertEqual(environmentVariables?["keyToBeSet"], isMuterRunningValue)
+        XCTAssertEqual(environmentVariables?[isMuterRunningKey], isMuterRunningValue)
+    }
+
     private func loadPlist(for fileName: String) throws -> [String: AnyHashable] {
         let data = try XCTUnwrap(
             FileManager.default

--- a/Tests/Configuration/configurationParsingTests.swift
+++ b/Tests/Configuration/configurationParsingTests.swift
@@ -25,4 +25,29 @@ final class ConfigurationParsingTests: MuterTestCase {
 
         XCTAssertEqual(configuration?.excludeFileList, ["ExampleApp"])
     }
+
+    func test_buildSystem_defaultsToExecutableBasename() throws {
+        let yaml = """
+        executable: /usr/bin/xcodebuild
+        arguments: [test]
+        """
+        let configuration = try MuterConfiguration(from: Data(yaml.utf8))
+
+        XCTAssertNil(configuration.explicitBuildSystem)
+        XCTAssertEqual(configuration.buildSystem, .xcodebuild)
+    }
+
+    func test_explicitBuildSystem_overridesWrapperExecutableName() throws {
+        // A wrapper executable whose filename isn't `xcodebuild` would otherwise resolve to `.unknown`;
+        // the explicit `buildSystem:` key forces the correct build system.
+        let yaml = """
+        executable: ./.muter-bin/wrapper.sh
+        arguments: [test]
+        buildSystem: xcodebuild
+        """
+        let configuration = try MuterConfiguration(from: Data(yaml.utf8))
+
+        XCTAssertEqual(configuration.explicitBuildSystem, .xcodebuild)
+        XCTAssertEqual(configuration.buildSystem, .xcodebuild)
+    }
 }

--- a/Tests/MutationSchemata/__Snapshots__/RewriterTests/test_allOperatorsWithImplicitReturnSourceCode.1.txt
+++ b/Tests/MutationSchemata/__Snapshots__/RewriterTests/test_allOperatorsWithImplicitReturnSourceCode.1.txt
@@ -169,7 +169,15 @@ struct ConditionalOperators {
       != nil
     {
     } else {
-      _ = foo(bar: { $0 == char })
+      _ = foo(bar: {
+        if ProcessInfo.processInfo.environment[
+          "sampleWithAllOperators_RelationalOperatorReplacement_26_27_586"] != nil
+        {
+          $0 != char
+        } else {
+          $0 == char
+        }
+      })
     }
   }
 }

--- a/Tests/MutationSteps/CopyProjectToTempDirectoryTests.swift
+++ b/Tests/MutationSteps/CopyProjectToTempDirectoryTests.swift
@@ -22,6 +22,26 @@ final class CopyProjectToTempDirectoryTests: MuterTestCase {
         XCTAssertEqual(fileManager.methodCalls, ["copyItem(atPath:toPath:)"])
     }
 
+    func test_whenTheCopyContainsModuleCaches_thenTheyAreDiscarded() async throws {
+        state.projectDirectoryURL = URL(fileURLWithPath: "/some/projectName")
+        state.mutatedProjectDirectoryURL = URL(fileURLWithPath: "/tmp/projectName")
+        process.stdoutToBeReturned = """
+        /tmp/projectName/.build/arm64-apple-macosx/debug/ModuleCache
+        /tmp/projectName/.build/arm64-apple-macosx/release/ModuleCache
+        """
+
+        _ = try await sut.run(with: state)
+
+        // A module cache records the absolute path it was built under, so one carried into the copy makes
+        // every compile there fail with `missing required module 'SwiftShims'`.
+        XCTAssertEqual(process.executableURL?.path, "/usr/bin/find")
+        XCTAssertEqual(process.arguments, ["/tmp/projectName", "-name", "ModuleCache"])
+        XCTAssertEqual(fileManager.paths, [
+            "/tmp/projectName/.build/arm64-apple-macosx/debug/ModuleCache",
+            "/tmp/projectName/.build/arm64-apple-macosx/release/ModuleCache",
+        ])
+    }
+
     func test_whenItsUnableToCopyAProjectIntoATempDirectory() async throws {
         fileManager.errorToThrow = TestingError.stub
         state.projectDirectoryURL = URL(string: "/some/projectName")!

--- a/Tests/MutationSteps/LoadConfigurationTests.swift
+++ b/Tests/MutationSteps/LoadConfigurationTests.swift
@@ -98,6 +98,72 @@ final class LoadConfigurationTests: MuterTestCase {
         }
     }
 
+    func test_whenExecutableIsABareCommandName_thenItIsResolvedToItsPathLocation() async throws {
+        fileManager.fileExistsToReturn = [false, true]
+        fileManager.fileContentsToReturn = MuterConfiguration(
+            executable: "swift",
+            arguments: ["test"]
+        ).asData
+        process.stdoutToBeReturned = "/usr/bin/swift\n"
+
+        let result = try await sut.run(with: state)
+
+        // A bare command name is only resolvable by searching PATH. Later steps run the test command
+        // from Muter's copy of the project, where `Process` would look for a file literally named
+        // "swift" — so the configuration has to carry the absolute path from here on.
+        XCTAssertEqual(process.executableURL?.path, "/usr/bin/which")
+        XCTAssertEqual(process.arguments, ["swift"])
+        XCTAssertEqual(
+            result.last,
+            .configurationParsed(
+                MuterConfiguration(executable: "/usr/bin/swift", arguments: ["test"])
+            )
+        )
+    }
+
+    func test_whenExecutableIsAnAbsolutePath_thenItIsLeftAlone() async throws {
+        fileManager.fileExistsToReturn = [false, true]
+        fileManager.fileContentsToReturn = MuterConfiguration(
+            executable: "/opt/homebrew/bin/swift",
+            arguments: ["test"]
+        ).asData
+
+        let result = try await sut.run(with: state)
+
+        XCTAssertNil(process.executableURL)
+        XCTAssertEqual(
+            result.last,
+            .configurationParsed(
+                MuterConfiguration(executable: "/opt/homebrew/bin/swift", arguments: ["test"])
+            )
+        )
+    }
+
+    func test_whenExecutableIsNotOnPath_thenFailWithAnActionableError() async throws {
+        fileManager.fileExistsToReturn = [false, true]
+        fileManager.fileContentsToReturn = MuterConfiguration(
+            executable: "swiftly",
+            arguments: ["test"]
+        ).asData
+
+        try await assertThrowsMuterError(
+            await sut.run(with: state)
+        ) { error in
+            // Reported verbatim: the configuration file itself parsed fine, so calling this a parsing
+            // error would point the user at the wrong problem.
+            guard case let .literal(reason) = error else {
+                XCTFail("Expected literal, got \(error)")
+                return
+            }
+
+            XCTAssertTrue(
+                reason.contains("swiftly"),
+                "Expected the error to name the executable it couldn't find, got: \(reason)"
+            )
+            XCTAssertTrue(reason.contains("PATH"), reason)
+        }
+    }
+
     func test_loadingConfigurationFromCustomPath() async throws {
         fileManager.fileContentsToReturn = loadYAMLConfiguration()
         fileManager.fileExistsToReturn = [false, true]

--- a/Tests/MutationTesting/MutationTestingAbortReasonTests.swift
+++ b/Tests/MutationTesting/MutationTestingAbortReasonTests.swift
@@ -1,0 +1,96 @@
+@testable import muterCore
+import TestingExtensions
+import XCTest
+
+final class MutationTestingAbortReasonTests: MuterTestCase {
+    private let mutatedFilePath = "/project/Sources/Calc/Calc.swift"
+
+    func test_whenBaselineFailedToCompileAMutatedFile_thenBlameMuterAndNameTheFileAndError() {
+        let log = """
+        Building for debugging...
+        /project_mutated/Sources/Calc/Calc.swift:8:24: error: expected expression after operator
+        error: fatalError
+        """
+
+        let description = MutationTestingAbortReason.baselineTestFailed(
+            log: log,
+            mutatedFilePaths: [mutatedFilePath]
+        ).description
+
+        XCTAssertTrue(
+            description.contains("Calc.swift:8:24: error: expected expression after operator"),
+            description
+        )
+        XCTAssertTrue(description.contains("bug in Muter's own rewriting"), description)
+        XCTAssertFalse(
+            description.contains("misconfiguring"),
+            "A mutant that doesn't compile is Muter's fault, so the message must not point at the user's configuration:\n\(description)"
+        )
+    }
+
+    func test_whenBaselineFailedWithACompileErrorInAFileMuterDidNotMutate_thenKeepTheConfigurationHint() {
+        let log = """
+        /project_mutated/Tests/CalcTests/CalcTests.swift:4:1: error: no such module 'Calc'
+        """
+
+        let description = MutationTestingAbortReason.baselineTestFailed(
+            log: log,
+            mutatedFilePaths: [mutatedFilePath]
+        ).description
+
+        XCTAssertTrue(description.contains("misconfiguring"), description)
+        XCTAssertFalse(description.contains("bug in Muter's own rewriting"), description)
+        XCTAssertTrue(description.contains("no such module 'Calc'"), description)
+    }
+
+    func test_whenBaselineFailedWithATestFailure_thenKeepTheConfigurationHint() {
+        let log = """
+        Test Case '-[CalcTests.CalcTests test_inRange]' failed (0.001 seconds).
+        Executed 2 tests, with 1 failure (0 unexpected) in 0.002 seconds
+        """
+
+        let description = MutationTestingAbortReason.baselineTestFailed(
+            log: log,
+            mutatedFilePaths: [mutatedFilePath]
+        ).description
+
+        XCTAssertTrue(description.contains("misconfiguring"), description)
+        XCTAssertTrue(description.contains("test_inRange"), description)
+    }
+
+    func test_whenThereIsNoLog_thenSayThereIsNoneRatherThanPrintingAnEmptySection() {
+        let description = MutationTestingAbortReason.baselineTestFailed(
+            log: "",
+            mutatedFilePaths: [mutatedFilePath]
+        ).description
+
+        XCTAssertTrue(description.contains("captured no output at all"), description)
+        XCTAssertFalse(
+            description.contains("Here's the log"),
+            "Promising a log and then printing nothing leaves the user with no evidence:\n\(description)"
+        )
+    }
+
+    func test_compilerErrorParsing() {
+        let log = """
+        Building for debugging...
+        /project/Calc.swift:8:24: error: expected expression after operator
+        /project/Calc.swift:9:1: warning: unused variable
+        /project/Calc.swift:10: error: missing a column
+        error: fatalError
+        note: /project/Other.swift:1:1: error: quoted inside a note
+        """
+
+        XCTAssertEqual(
+            CompilerError.all(in: log),
+            [
+                CompilerError(
+                    filePath: "/project/Calc.swift",
+                    line: 8,
+                    column: 24,
+                    message: "expected expression after operator"
+                ),
+            ]
+        )
+    }
+}

--- a/Tests/MutationTesting/MutationTestingDelegateTests.swift
+++ b/Tests/MutationTesting/MutationTestingDelegateTests.swift
@@ -172,6 +172,30 @@ final class MutationTestingDelegateTests: MuterTestCase {
         XCTAssertEqual(result.outcome, .timeout)
     }
 
+    func test_whenTestProcessCannotBeLaunched_thenTheFailureIsReportedAsTheLog() async throws {
+        let configuration = MuterConfiguration(
+            executable: "swift",
+            arguments: ["test", "--filter", "CalcTests"]
+        )
+        process.runError = NSError(
+            domain: NSCocoaErrorDomain,
+            code: NSFileNoSuchFileError,
+            userInfo: [NSLocalizedDescriptionKey: "The file \"swift\" doesn't exist."]
+        )
+
+        let result = await sut.benchmarkTests(
+            using: configuration,
+            savingResultsIntoFileNamed: "logFileName"
+        )
+
+        // A process that never launches produces no test output, so the spawn failure itself is the only
+        // evidence there is. An empty log here leaves the abort message with nothing to show the user.
+        XCTAssertEqual(result.outcome, .buildError)
+        XCTAssertTrue(result.testLog.contains("swift"), result.testLog)
+        XCTAssertTrue(result.testLog.contains("test --filter CalcTests"), result.testLog)
+        XCTAssertTrue(result.testLog.contains("doesn't exist"), result.testLog)
+    }
+
     func test_whenConfigurationHasNoTimeOut_thenRunTestsWithoutTimeOut() async throws {
         let configuration = MuterConfiguration(
             executable: "/tmp/swift",

--- a/Tests/MutationTesting/MutationTestingDelegateTests.swift
+++ b/Tests/MutationTesting/MutationTestingDelegateTests.swift
@@ -76,9 +76,21 @@ final class MutationTestingDelegateTests: MuterTestCase {
         )
 
         XCTAssertEqual(testProcess.environment?[schemata.id], "YES")
+        // Also forwarded with the SIMCTL_CHILD_ prefix so it reaches an iOS Simulator test host
+        // (CoreSimulator only propagates SIMCTL_CHILD_-prefixed vars into the simulated process).
+        XCTAssertEqual(testProcess.environment?["SIMCTL_CHILD_\(schemata.id)"], "YES")
         XCTAssertEqual(testProcess.environment?[isMuterRunningKey], isMuterRunningValue)
         XCTAssertEqual(testProcess.arguments, ["test", "--skip-build"])
         XCTAssertEqual(testProcess.executableURL?.path, "/tmp/swift")
+    }
+
+    func test_makeProcess_doesNotSetMuterRunningMarker() {
+        // The shared factory (used for build-for-testing too) must NOT carry IS_MUTER_RUNNING — on
+        // some projects it makes xcodebuild skip writing build-request.json, breaking BuildForTesting.
+        // The marker belongs only on the test process (asserted in test_testProcessForSwiftBuild).
+        let process = MuterProcessFactory.makeProcess()
+
+        XCTAssertNil(process.environment?[isMuterRunningKey])
     }
 
     func test_switchOn() async throws {

--- a/Tests/MutationTesting/MutationTestingDelegateTests.swift
+++ b/Tests/MutationTesting/MutationTestingDelegateTests.swift
@@ -134,6 +134,32 @@ final class MutationTestingDelegateTests: MuterTestCase {
         XCTAssertEqual(testingTimeOutExecutor.timeLimitPassed, 9)
     }
 
+    func test_whenTestTimesOut_thenKillsProcessTreeAndReportsTimeout() async throws {
+        let configuration = MuterConfiguration(
+            executable: "/tmp/swift",
+            arguments: ["test"],
+            testSuiteTimeOut: 9
+        )
+        // Force the timeout branch (the test "ran too long").
+        testingTimeOutExecutor.shouldSucceed = false
+
+        let schemata = try MutationSchema.make(
+            filePath: "/path/fileName",
+            position: .init(line: 1)
+        )
+
+        let result = await sut.runTestSuite(
+            withSchemata: schemata,
+            using: configuration,
+            savingResultsIntoFileNamed: "logFileName"
+        )
+
+        // On timeout we kill the WHOLE process tree (not just interrupt the parent), and the mutant
+        // is reported as timed out rather than hanging the run forever.
+        XCTAssertTrue(process.terminateTreeCalled)
+        XCTAssertEqual(result.outcome, .timeout)
+    }
+
     func test_whenConfigurationHasNoTimeOut_thenRunTestsWithoutTimeOut() async throws {
         let configuration = MuterConfiguration(
             executable: "/tmp/swift",

--- a/Tests/MutationTesting/PerformMutationTestingTests.swift
+++ b/Tests/MutationTesting/PerformMutationTestingTests.swift
@@ -97,7 +97,7 @@ final class PerformMutationTestingTests: MuterTestCase {
         try await assertThrowsMuterError(
             await sut.run(with: state)
         ) { error in
-            guard case let .mutationTestingAborted(reason: .baselineTestFailed(log)) = error else {
+            guard case let .mutationTestingAborted(reason: .baselineTestFailed(log, _)) = error else {
                 XCTFail("Expected mutationTestingAborted, got \(error)")
                 return
             }
@@ -117,7 +117,7 @@ final class PerformMutationTestingTests: MuterTestCase {
         try await assertThrowsMuterError(
             await sut.run(with: state)
         ) { error in
-            guard case let .mutationTestingAborted(reason: .baselineTestFailed(log)) = error else {
+            guard case let .mutationTestingAborted(reason: .baselineTestFailed(log, _)) = error else {
                 XCTFail("Expected mutationTestingAborted, got \(error)")
                 return
             }
@@ -136,7 +136,7 @@ final class PerformMutationTestingTests: MuterTestCase {
         try await assertThrowsMuterError(
             await sut.run(with: state)
         ) { error in
-            guard case let .mutationTestingAborted(reason: .baselineTestFailed(log)) = error else {
+            guard case let .mutationTestingAborted(reason: .baselineTestFailed(log, _)) = error else {
                 XCTFail("Expected mutationTestingAborted, got \(error)")
                 return
             }
@@ -147,6 +147,52 @@ final class PerformMutationTestingTests: MuterTestCase {
         XCTAssertEqual(ioDelegate.methodCalls, [
             "benchmarkTests(using:savingResultsIntoFileNamed:)",
         ])
+    }
+
+    func test_whenBaselineFails_thenItsLogIsStillPublishedForWritingToDisk() async throws {
+        ioDelegate.testSuiteOutcomes = [.buildError]
+
+        // The baseline's output is the only evidence of why Muter can't start, and nothing else records
+        // it — so it has to be published even though the run is about to be aborted.
+        let expect = expectation(
+            forNotification: .baselineTestFailed,
+            object: nil,
+            notificationCenter: notificationCenter
+        ) { notification in
+            (notification.object as? MutationTestLog)?.mutationPoint == nil
+        }
+
+        // …and not as `.newTestLogAvailable`, which announces "Determined baseline for mutation
+        // testing" and starts the progress bar — neither of which happened.
+        let announcedSuccess = expectation(
+            forNotification: .newTestLogAvailable,
+            object: nil,
+            notificationCenter: notificationCenter
+        )
+        announcedSuccess.isInverted = true
+
+        try await assertThrowsMuterError(
+            await sut.run(with: state)
+        ) { _ in }
+
+        await fulfillment(of: [expect, announcedSuccess], timeout: 2)
+    }
+
+    func test_whenBaselineFails_thenTheAbortReasonCarriesTheMutatedFilePaths() async throws {
+        ioDelegate.testSuiteOutcomes = [.buildError]
+
+        try await assertThrowsMuterError(
+            await sut.run(with: state)
+        ) { error in
+            guard case let .mutationTestingAborted(reason: .baselineTestFailed(_, mutatedFilePaths)) = error else {
+                XCTFail("Expected mutationTestingAborted, got \(error)")
+                return
+            }
+
+            // Naming the files Muter rewrote is what lets the message tell a broken mutant apart from
+            // a misconfigured test command.
+            XCTAssertEqual(mutatedFilePaths, ["/some/path", "/some/path"])
+        }
     }
 
     func test_whenEncountersFiveConsecutiveBuildErrors_thenCancelMutationTesting() async throws {

--- a/Tests/TestDoubles/ProcessSpy.swift
+++ b/Tests/TestDoubles/ProcessSpy.swift
@@ -19,8 +19,15 @@ final class ProcessSpy: MuterProcess {
     }
 
     var runCalled = false
+    /// Set to simulate a process that can't be launched at all — what `Foundation.Process.run()` throws
+    /// when `executableURL` names a file that doesn't exist.
+    var runError: Error?
     func run() throws {
         runCalled = true
+
+        if let runError {
+            throw runError
+        }
     }
 
     var waitUntilExitCalled = false

--- a/Tests/TestDoubles/ProcessSpy.swift
+++ b/Tests/TestDoubles/ProcessSpy.swift
@@ -2,6 +2,7 @@ import Foundation
 @testable import muterCore
 
 final class ProcessSpy: MuterProcess {
+    var processIdentifier: Int32 { 0 }
     var terminationStatus: Int32 { 0 }
     var terminationHandler: (@Sendable (Foundation.Process) -> Void)? = nil
     var environment: [String: String]?
@@ -42,4 +43,11 @@ final class ProcessSpy: MuterProcess {
     }
 
     func interrupt() {}
+
+    // Override the protocol's default `terminateTree()` so tests can assert the timeout handler
+    // reaches for the tree-kill without invoking the real `ps`/`kill` path.
+    private(set) var terminateTreeCalled = false
+    func terminateTree() {
+        terminateTreeCalled = true
+    }
 }


### PR DESCRIPTION
## Summary

On `master`, `muter run` over an SPM package reports every mutant as survived — a 0% score
regardless of test-suite quality — and a run that gets that far is the lucky case: on a package
whose `executable` is a bare name it aborts before running anything, blaming your configuration.

This branch fixes the whole chain, in eight independent commits each with a regression test.
**It now also contains the rewriter fix from #310** (see *Relationship to #310* below).

## Why the score was always 0% — two causes, both required

Schemata never reached the file, for two separate reasons, and fixing either alone leaves the other
in place:

1. **The mapping lookup missed after a re-parse.** `DiscoverMutationPoints` deliberately returns an
   empty source cache, so `ApplySchemata` re-parses each file and looks up by syntax-node identity.
   Identity does not survive a re-parse, so every lookup missed: the rewriter wrote its header and
   inserted zero switches. Fixed by keying the mapping on the code block's stable source position
   plus its text (`e4a3806`).

2. **Wrapping a block moved its nested blocks.** `MuterRewriter.visit` applied the switch and then
   visited the children of the *synthesized* node. Wrapping shifts every nested block's position, so
   a closure or ternary body had its mutants discovered and then silently dropped. Fixed by
   rewriting the children of the original node first and making the result the switch's default
   branch (`5be334d`, from #310).

The second cause is invisible until the first is fixed, which is why each PR measured a partial
result alone. Concretely, on a 300-line analyzer with 10 mutants whose suite kills all ten when the
mutations are applied by hand: **cause 1 alone → 90%**, one survivor, and that survivor was a
ternary — exactly the nested case. **Both → 100%**, no survivors. The last "surviving mutant" was
never a gap in the test suite; it was a mutant that never reached the file.

## The other defects

3. **Ternary swap corrupted the source** (`c19858f`, #308). Swapping a ternary whose else-expression
   is a comparison produced invalid Swift, e.g. `return isRegistered(x) ? a : b` became
   `return isRegistered(x)? nil`. The mutant then failed to compile and was reported as a
   configuration problem.

4. **A bare `executable` could not launch** (`d1c6371`). `executable: swift` — the form the README
   and every shell habit suggest — was passed straight to `Process.executableURL`, which resolves a
   non-absolute name against the current working directory. By then that directory is Muter's copy
   of the project, where no `swift` exists, so `process.run()` threw `ENOENT` before the command
   emitted a line. The throw was swallowed into `(.buildError, "")` — which is why the abort printed
   an empty log.

5. **A copied `.build` could not compile** (`8433885`). The project copy inherits precompiled module
   caches whose absolute paths point at the original directory, so the copy fails with
   `missing required module 'SwiftShims'`. The caches are now discarded on copy.

6. **The abort blamed your configuration for Muter's bug** (`0654d53`). "usually due to
   misconfiguring the executable and arguments" was printed even when the real cause was an invalid
   mutant or a launch failure, and the XCTest log it offered as evidence was empty. It now reports
   what actually failed, and names the mutated file when a mutant is the reason.

7. **Orphaned test processes on timeout** (`0eeac13`, hardens #279) — the whole process tree is
   killed, not just the parent.

8. **Mutants not activated on iOS Simulator targets** (`45573b9`) — another route to a phantom 0%.

## Relationship to #310

@YamanBoztepe's #310 diagnosed cause 1 identically and independently, and additionally found cause
2, which this branch was missing. That rewriter fix is now included here with credit and a
`Co-authored-by` trailer.

The two branches differ on cause 1: #310 adds an offset-keyed fallback and keeps the identity
dictionary as a fast path, while this branch replaces the key with position + text. I kept the
latter — the identity path can never hit in the real flow, since `ApplySchemata` always re-parses,
and including the text means a lookup misses rather than applying a schema to source that changed
between discovery and application. That is a judgement call, not a correctness claim; the fallback
approach also works, and a maintainer preferring the smaller diff on that file would lose nothing.

I am not suggesting #310 be closed — its author found a real bug this branch did not. If it is
easier to land #310 first, this branch rebases onto it cleanly, since only `SchemataMutationMapping`
would conflict.

## Verification

- `swift test --filter "Rewriter|Schemata"`: 12/12.
- Full suite: 204 tests, 1 failure — `LoggerTests.test_printer`, an ANSI-coloured snapshot that
  fails **identically on upstream `master`** and is terminal-capability dependent. No new failures.
- End to end on a real SPM package: the run now completes and reports a real score where before it
  aborted at the baseline.
- **Note on the red check:** `master`'s own CI is currently failing
  (`repos/muter-mutation-testing/muter/commits/master/status` → `failure`), so the red on this PR is
  not introduced by these commits.

## Commits

- `e4a3806` fix: key schemata mapping by stable source position so schemata actually apply (#307)
- `c19858f` fix: don't corrupt ternary swap when else-expression is a comparison (#308)
- `0eeac13` fix: kill the whole process tree on test timeout, not just the parent (#279)
- `45573b9` fix: activate mutants on iOS Simulator targets (phantom 0% fix)
- `d1c6371` fix: resolve a bare `executable` on PATH so the test command can launch
- `8433885` fix: discard copied module caches so the mutated project can compile
- `0654d53` fix: report why the baseline failed instead of blaming the configuration
- `5be334d` fix: rewrite children before wrapping, so nested blocks keep their mutants
