### PR TITLE
Fix schemata never being applied after a re-parse (SPM score always 0%)

### DIFF
--- a/Sources/muterCore/MutationSchemata/SchemataMutationMapping.swift
+++ b/Sources/muterCore/MutationSchemata/SchemataMutationMapping.swift
@@ -6,6 +6,7 @@ typealias MutationSchemata = [MutationSchema]
 final class SchemataMutationMapping {
     let filePath: String
     fileprivate var mappings: [CodeBlockItemListSyntax: MutationSchemata]
+    private var mappingsByPosition: [Int: MutationSchemata] = [:]
 
     var count: Int {
         mappings.count
@@ -42,6 +43,9 @@ final class SchemataMutationMapping {
     ) {
         self.filePath = filePath
         self.mappings = mappings
+        for (codeBlock, schemata) in mappings {
+            mappingsByPosition[codeBlock.position.utf8Offset, default: []].append(contentsOf: schemata)
+        }
     }
 
     func add(
@@ -49,6 +53,7 @@ final class SchemataMutationMapping {
         _ schemata: MutationSchema
     ) {
         mappings[codeBlockSyntax, default: []].append(schemata)
+        mappingsByPosition[codeBlockSyntax.position.utf8Offset, default: []].append(schemata)
     }
 
     func add(
@@ -56,12 +61,13 @@ final class SchemataMutationMapping {
         _ schemata: MutationSchemata
     ) {
         mappings[codeBlockSyntax, default: []].append(contentsOf: schemata)
+        mappingsByPosition[codeBlockSyntax.position.utf8Offset, default: []].append(contentsOf: schemata)
     }
 
     func schemata(
         _ codeBlockSyntax: CodeBlockItemListSyntax
     ) -> MutationSchemata? {
-        mappings[codeBlockSyntax]
+        mappings[codeBlockSyntax] ?? mappingsByPosition[codeBlockSyntax.position.utf8Offset]
     }
 }
 

--- a/Sources/muterCore/Rewriters/MuterRewriter.swift
+++ b/Sources/muterCore/Rewriters/MuterRewriter.swift
@@ -12,11 +12,11 @@ final class MuterRewriter: SyntaxRewriter {
             return super.visit(node)
         }
 
-        let newNode = MutationSwitch.apply(
-            mutationSchemata: mutationSchemata,
-            with: node
-        )
+        let childrenRewritten = super.visit(node)
 
-        return super.visit(newNode)
+        return MutationSwitch.apply(
+            mutationSchemata: mutationSchemata,
+            with: childrenRewritten
+        )
     }
 }

--- a/Tests/MutationSchemata/__Snapshots__/RewriterTests/test_allOperatorsWithImplicitReturnSourceCode.1.txt
+++ b/Tests/MutationSchemata/__Snapshots__/RewriterTests/test_allOperatorsWithImplicitReturnSourceCode.1.txt
@@ -169,7 +169,15 @@ struct ConditionalOperators {
       != nil
     {
     } else {
-      _ = foo(bar: { $0 == char })
+      _ = foo(bar: {
+        if ProcessInfo.processInfo.environment[
+          "sampleWithAllOperators_RelationalOperatorReplacement_26_27_586"] != nil
+        {
+          $0 != char
+        } else {
+          $0 == char
+        }
+      })
     }
   }
 }


### PR DESCRIPTION
## Summary

On current `master`, running `muter run` on an SPM project reports **0 killed / all survived** regardless of test suite quality: the mutation switches are never written to disk, so every "mutant run" executes the original, unmutated binary. This PR fixes the two causes.

### 1. Mapping lookups miss after a re-parse

`DiscoverMutationPoints` intentionally returns an empty source cache (memory optimization: *"Pass empty dictionary - ApplySchemata will re-parse files on demand"*). `ApplySchemata` then re-parses each file and calls `SchemataMutationMapping.schemata(node)`, which is a dictionary lookup **keyed by syntax node identity**. Node identity does not survive a re-parse: the keys belong to the discovery-time tree, the lookup nodes to the freshly parsed tree, so every lookup misses. `MuterRewriter` still visits the file (the `// swiftformat:disable all` header is written) but inserts zero switches. The baseline then builds clean code, per-mutant runs use `--skip-build` with an activation env var pointing at switches that don't exist, and every mutant "survives".

**Fix:** add a fallback index keyed by the code block's `position.utf8Offset`, which is stable across re-parses of identical text. The identity-keyed dictionary stays as the fast path.

### 2. Nested code blocks lose their mutants

`MuterRewriter.visit` applied the outer block's switch first and then visited the children of the freshly **synthesized** node, so nested code blocks (closures, ternaries) could never match their mapping entries — their mutants were silently skipped even when the top-level lookup worked. The existing reference snapshot `test_allOperatorsWithImplicitReturnSourceCode` actually enshrines this: the `$0 == char` mutant inside `foo(bar: { ... })` gets no switch.

**Fix:** rewrite the children first (`super.visit(node)` on the original node, where identities still match) and make the result the switch's default branch. The snapshot is updated accordingly — the nested closure now receives its switch.

## Verification

- Real-world SPM package, 116 tests (Swift Testing): before this PR 45/45 mutants survived (score 0%); after, 42 killed + 3 timeouts from mutants that introduce genuine infinite loops — hand-applying the same mutations confirms the kills are real.
- A file watcher polling the mutated copy during an unpatched run confirms the switch marker never reaches disk; `strings` on the built test binary contains no schema ids. Both checks pass after the patch.
- `swift test --filter "Rewriter|Schemata"`: 12/12 after the snapshot update.
- Full `swift test` on this branch and on `master` fail with the **identical** set of 19 pre-existing environment-dependent tests (acceptance/regression fixtures) on macOS arm64 / Swift 6.2 — this PR introduces no new failures.
